### PR TITLE
fix: render inline HTML elements and close formatting markers at line end

### DIFF
--- a/markanywhere-parse/src/commonMain/kotlin/MarkanywhereParser.kt
+++ b/markanywhere-parse/src/commonMain/kotlin/MarkanywhereParser.kt
@@ -970,6 +970,54 @@ private class ParserState(
     }
 
     /**
+     * Returns true if `name` is a valid HTML tag name: starts with a letter,
+     * followed by letters, digits, or hyphens only.
+     */
+    private fun isValidHtmlTagName(name: String): Boolean =
+        name.isNotEmpty() && name[0].isLetter() && name.all { it.isLetterOrDigit() || it == '-' }
+
+    /**
+     * Tries to emit an inline HTML tag from the content inside `< >`.
+     * Handles opening tags (`<p>`), closing tags (`</p>`), and self-closing tags (`<br/>`).
+     * Returns true if the content was recognized as an HTML tag and emitted, false otherwise.
+     *
+     * Inline HTML requires the tag name to start immediately after `<` (no leading whitespace),
+     * which distinguishes `<div>` (HTML tag) from `< b >` (comparison with spaces, not HTML).
+     */
+    private suspend fun SemanticEventScope.tryEmitInlineHtmlTag(content: String): Boolean {
+        // Tag name must start immediately after '<' — reject anything with leading whitespace
+        if (content.isEmpty() || (!content[0].isLetter() && content[0] != '/')) return false
+
+        val trimmed = content.trim()
+
+        // Closing tag: /tagname
+        if (trimmed.startsWith("/")) {
+            val tagName = trimmed.substring(1).trim()
+            if (isValidHtmlTagName(tagName)) {
+                unmark(tagName, isTag = true)
+                return true
+            }
+            return false
+        }
+
+        // Self-closing tag ends with /
+        val isSelfClosing = trimmed.endsWith("/")
+        val contentWithoutSlash = if (isSelfClosing) trimmed.dropLast(1).trim() else trimmed
+
+        // Opening tag: tagname [attrs]
+        val parts = contentWithoutSlash.split(Patterns.WHITESPACE, limit = 2)
+        val tagName = parts[0]
+        if (!isValidHtmlTagName(tagName)) return false
+
+        val attrs = if (parts.size > 1) parseAttributes(parts[1]) else null
+        mark(tagName, isTag = true, attributes = attrs)
+        if (isSelfClosing) {
+            unmark(tagName, isTag = true)
+        }
+        return true
+    }
+
+    /**
      * Process content inside a custom markup block.
      * Content is emitted immediately as it arrives.
      * Closing tag is detected incrementally when </tagname> pattern is seen.
@@ -1183,21 +1231,21 @@ private class ParserState(
             return
         }
 
-        // Autolinks
+        // Autolinks and inline HTML
         if (inlineBuffer.startsWith("<")) {
             if (char == '>') {
                 val content = inlineBuffer.substring(1)
                 inlineBuffer.clear()
-                if (content.contains("@") && !content.contains("://")) {
-                    "a"("href" to "mailto:$content") {
-                        +content
-                    }
-                } else if (content.contains("://")) {
-                    "a"("href" to content) {
-                        +content
-                    }
-                } else {
-                    +"<$content>"
+                when {
+                    // Inline HTML: tag name starts immediately after '<' (no leading whitespace)
+                    tryEmitInlineHtmlTag(content) -> { /* Emitted as inline HTML mark/unmark event */ }
+                    // Email autolink
+                    content.contains("@") && !content.contains("://") ->
+                        "a"("href" to "mailto:$content") { +content }
+                    // URL autolink
+                    content.contains("://") ->
+                        "a"("href" to content) { +content }
+                    else -> +"<$content>"
                 }
                 return
             } else {
@@ -1479,6 +1527,23 @@ private class ParserState(
     }
 
     private suspend fun SemanticEventScope.flushInline() {
+        // If the inline buffer holds a closing formatting marker (e.g. the trailing "**" of
+        // "**bold**"), discard it rather than emitting as literal text. The active-state flags
+        // below will take care of emitting the corresponding Unmark events.
+        val bufStr = inlineBuffer.toString()
+        val isClosingMarker = when (bufStr) {
+            "**", "__" -> bold
+            "*", "_" -> italic && !bold
+            "***", "___" -> bold && italic
+            "~~" -> strikethrough
+            "~" -> subscript
+            "==" -> highlight
+            else -> false
+        }
+        if (isClosingMarker) {
+            inlineBuffer.clear()
+        }
+
         if (inlineBuffer.isNotEmpty()) {
             +inlineBuffer.toString()
             inlineBuffer.clear()

--- a/markanywhere-parse/src/commonMain/kotlin/MarkanywhereParser.kt
+++ b/markanywhere-parse/src/commonMain/kotlin/MarkanywhereParser.kt
@@ -891,7 +891,15 @@ private class ParserState(
     ) {
         lineBuffer.append(char)
         if (char == '\n') {
-            val line = lineBuffer.toString().trimEnd()
+            val lineContent = lineBuffer.toString()
+            // Support multi-line HTML tables inside table cells: when the accumulated
+            // content has an unclosed <table> tag, strip the newline and keep buffering
+            // so that the HTML table is treated as a single cell value.
+            if (lineContent.htmlTableNestingDepth() > 0) {
+                lineBuffer.deleteAt(lineBuffer.length - 1)
+                return
+            }
+            val line = lineContent.trimEnd()
             if (line.startsWith("|")) {
                 "tr" {
                     emitTableRow(line, isHeader = false)
@@ -983,32 +991,40 @@ private class ParserState(
      *
      * Inline HTML requires the tag name to start immediately after `<` (no leading whitespace),
      * which distinguishes `<div>` (HTML tag) from `< b >` (comparison with spaces, not HTML).
+     * Tag names are normalised to lowercase so consumers always receive consistent event names.
      */
     private suspend fun SemanticEventScope.tryEmitInlineHtmlTag(content: String): Boolean {
-        // Tag name must start immediately after '<' — reject anything with leading whitespace
+        // Reject '<' followed by whitespace or anything other than a letter or '/'.
+        // The '/' guard handles closing tags like '</div>'; opening tags are further
+        // validated by isValidHtmlTagName which also requires the name to start with a letter.
         if (content.isEmpty() || (!content[0].isLetter() && content[0] != '/')) return false
 
         val trimmed = content.trim()
 
-        // Closing tag: /tagname
+        // Closing tag: /tagname — normalise to lowercase for consistent Unmark names
         if (trimmed.startsWith("/")) {
-            val tagName = trimmed.substring(1).trim()
-            if (isValidHtmlTagName(tagName)) {
-                unmark(tagName, isTag = true)
+            val tagNameRaw = trimmed.substring(1).trim()
+            if (isValidHtmlTagName(tagNameRaw)) {
+                unmark(tagNameRaw.lowercase(), isTag = true)
                 return true
             }
             return false
         }
 
-        // Self-closing tag ends with /
+        // Self-closing detection via endsWith("/") on the trimmed content.
+        // This is safe for the common cases: <br/>, <br />, <img src="url"/>.
+        // An attribute value ending with '/' (e.g. <img src="path/">) is safe because
+        // the content here is only the part between '<' and '>', with '>' stripped, so
+        // such values end with '"' not '/'.
         val isSelfClosing = trimmed.endsWith("/")
         val contentWithoutSlash = if (isSelfClosing) trimmed.dropLast(1).trim() else trimmed
 
-        // Opening tag: tagname [attrs]
+        // Opening tag: tagname [attrs] — normalise to lowercase for consistent Mark names
         val parts = contentWithoutSlash.split(Patterns.WHITESPACE, limit = 2)
-        val tagName = parts[0]
-        if (!isValidHtmlTagName(tagName)) return false
+        val tagNameRaw = parts[0]
+        if (!isValidHtmlTagName(tagNameRaw)) return false
 
+        val tagName = tagNameRaw.lowercase()
         val attrs = if (parts.size > 1) parseAttributes(parts[1]) else null
         mark(tagName, isTag = true, attributes = attrs)
         if (isSelfClosing) {
@@ -1532,7 +1548,11 @@ private class ParserState(
         // below will take care of emitting the corresponding Unmark events.
         val bufStr = inlineBuffer.toString()
         val isClosingMarker = when (bufStr) {
+            // bold alone is sufficient here: if "**" is buffered while both bold and
+            // italic are active, discarding it is still correct (flushInline closes both).
             "**", "__" -> bold
+            // !bold guards against discarding a lone '*' mid-bold (e.g. **bold*stray)
+            // where italic is false, so we must not treat that '*' as a closing marker.
             "*", "_" -> italic && !bold
             "***", "___" -> bold && italic
             "~~" -> strikethrough
@@ -1692,4 +1712,37 @@ private class ParserState(
             }
         }
     }
+}
+
+/**
+ * Returns the nesting depth of unclosed `<table>` elements in this string.
+ * A positive value means there is at least one `<table>` opened but not yet closed,
+ * which indicates that a Markdown table row spans multiple source lines.
+ * Self-closing `<table/>` tags are not counted as opened.
+ */
+private fun String.htmlTableNestingDepth(): Int {
+    val lower = lowercase()
+    var opens = 0
+    var pos = 0
+    while (true) {
+        val idx = lower.indexOf("<table", pos)
+        if (idx == -1) break
+        // Distinguish <table> / <table ...> (opening) from <table/> (self-closing).
+        // Valid opening: next char after "table" is '>', ' ', '\t', '\n', '\r', or end of string.
+        // Self-closing: next char is '/'.
+        val nextChar = lower.getOrElse(idx + 6) { '\u0000' }
+        if (nextChar != '/') {
+            opens++
+        }
+        pos = idx + 1
+    }
+    var closes = 0
+    pos = 0
+    while (true) {
+        val idx = lower.indexOf("</table>", pos)
+        if (idx == -1) break
+        closes++
+        pos = idx + 1
+    }
+    return opens - closes
 }

--- a/markanywhere-parse/src/commonTest/kotlin/MarkanywhereParserTest.kt
+++ b/markanywhere-parse/src/commonTest/kotlin/MarkanywhereParserTest.kt
@@ -405,7 +405,10 @@ class MarkanywhereParserTest {
     fun `should escape HTML special characters in text`() = runTest {
         // given
         val parser = DefaultMarkanywhereParser()
-        // Note: '<' followed by a space is NOT treated as an HTML tag (must start immediately with letter/'/')
+        // Note: '< div >' has a space after '<', so it is NOT treated as an inline HTML tag
+        // (the parser requires the tag name to start immediately after '<').
+        // Using '< div >' rather than '<div>' lets us test literal angle-bracket escaping
+        // without triggering the HTML tag path; the separate inline-HTML tests cover '<div>'.
         val textFlow = """
             Use < div > elements and & ampersands and "quotes" carefully.
         """.trimIndent().chunkedRandomly().asFlow()
@@ -2141,6 +2144,178 @@ class MarkanywhereParserTest {
             <p>
               This is <strong><em>bold italic</em></strong>
             </p>
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should close underscore italic markers at end of line`() = runTest {
+        // given
+        val parser = DefaultMarkanywhereParser()
+        val textFlow = """
+            This is _italic_
+        """.trimIndent().chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse(parser)
+
+        // then
+        parsed.render() sameAs """
+            <p>
+              This is <em>italic</em>
+            </p>
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should close underscore bold markers at end of line`() = runTest {
+        // given
+        val parser = DefaultMarkanywhereParser()
+        val textFlow = """
+            This is __bold__
+        """.trimIndent().chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse(parser)
+
+        // then
+        parsed.render() sameAs """
+            <p>
+              This is <strong>bold</strong>
+            </p>
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should render br with space before slash`() = runTest {
+        // given
+        val parser = DefaultMarkanywhereParser()
+        val textFlow = """
+            Line one<br />line two.
+        """.trimIndent().chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse(parser)
+
+        // then
+        parsed.render() sameAs """
+            <p>
+              Line one<br/>line two.
+            </p>
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should normalize inline HTML tag names to lowercase`() = runTest {
+        // given
+        val parser = DefaultMarkanywhereParser()
+        val textFlow = """
+            This has <STRONG>bold</STRONG> and <Em>italic</Em> HTML.
+        """.trimIndent().chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse(parser)
+
+        // then
+        parsed.render() sameAs """
+            <p>
+              This has <strong>bold</strong> and <em>italic</em> HTML.
+            </p>
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should render HTML table inside Markdown table cell`() = runTest {
+        // This is the primary use case from issue #25: an HTML table element
+        // embedded in a Markdown table cell on a single line.
+        // given
+        val parser = DefaultMarkanywhereParser()
+        val textFlow = """
+            |a|b|
+            |-|-|
+            |<table></table>|<p>abc</p>|
+        """.trimIndent().chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse(parser)
+
+        // then
+        parsed.render() sameAs """
+            <table>
+              <thead>
+                <tr>
+                  <th>
+                    a
+                  </th>
+                  <th>
+                    b
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>
+                    <table>
+                    </table>
+                  </td>
+                  <td>
+                    <p>
+                      abc
+                    </p>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should render multi-line HTML table inside Markdown table cell`() = runTest {
+        // A full HTML table spanning multiple lines inside a Markdown table cell.
+        // The parser buffers lines until the <table> is closed, then processes
+        // the entire cell content as a single unit.
+        // given
+        val parser = DefaultMarkanywhereParser()
+        val textFlow = """
+            |a|b|
+            |-|-|
+            |<table>
+            <tr><td>nested</td></tr>
+            </table>|text|
+        """.trimIndent().chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse(parser)
+
+        // then
+        parsed.render() sameAs """
+            <table>
+              <thead>
+                <tr>
+                  <th>
+                    a
+                  </th>
+                  <th>
+                    b
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>
+                    <table>
+                      <tr>
+                        <td>
+                          nested
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                  <td>
+                    text
+                  </td>
+                </tr>
+              </tbody>
+            </table>
         """.trimIndent()
     }
 

--- a/markanywhere-parse/src/commonTest/kotlin/MarkanywhereParserTest.kt
+++ b/markanywhere-parse/src/commonTest/kotlin/MarkanywhereParserTest.kt
@@ -405,8 +405,9 @@ class MarkanywhereParserTest {
     fun `should escape HTML special characters in text`() = runTest {
         // given
         val parser = DefaultMarkanywhereParser()
+        // Note: '<' followed by a space is NOT treated as an HTML tag (must start immediately with letter/'/')
         val textFlow = """
-            Use <div> elements and & ampersands and "quotes" carefully.
+            Use < div > elements and & ampersands and "quotes" carefully.
         """.trimIndent().chunkedRandomly().asFlow()
 
         // when
@@ -415,7 +416,7 @@ class MarkanywhereParserTest {
         // then
         parsed.render() sameAs """
             <p>
-              Use &lt;div&gt; elements and &amp; ampersands and "quotes" carefully.
+              Use &lt; div &gt; elements and &amp; ampersands and "quotes" carefully.
             </p>
         """.trimIndent()
     }
@@ -1968,6 +1969,179 @@ class MarkanywhereParserTest {
                 }
             }
         }
+    }
+
+    @Test
+    fun `should render inline HTML elements as semantic events`() = runTest {
+        // given
+        val parser = DefaultMarkanywhereParser()
+        val textFlow = """
+            This has <strong>bold</strong> and <em>italic</em> HTML.
+        """.trimIndent().chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse(parser)
+
+        // then
+        parsed.render() sameAs """
+            <p>
+              This has <strong>bold</strong> and <em>italic</em> HTML.
+            </p>
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should render inline HTML elements in table cells`() = runTest {
+        // given
+        val parser = DefaultMarkanywhereParser()
+        val textFlow = """
+            |a|b|
+            |-|-|
+            |<strong>bold</strong>|<em>italic</em>|
+        """.trimIndent().chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse(parser)
+
+        // then
+        parsed.render() sameAs """
+            <table>
+              <thead>
+                <tr>
+                  <th>
+                    a
+                  </th>
+                  <th>
+                    b
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>
+                    <strong>bold</strong>
+                  </td>
+                  <td>
+                    <em>italic</em>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should render self-closing inline HTML elements`() = runTest {
+        // given
+        val parser = DefaultMarkanywhereParser()
+        val textFlow = """
+            Line one<br/>line two.
+        """.trimIndent().chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse(parser)
+
+        // then
+        parsed.render() sameAs """
+            <p>
+              Line one<br/>line two.
+            </p>
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should render inline HTML with attributes`() = runTest {
+        // given
+        val parser = DefaultMarkanywhereParser()
+        val textFlow = """
+            Click <a href="https://example.com">here</a> for more.
+        """.trimIndent().chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse(parser)
+
+        // then
+        parsed.render() sameAs """
+            <p>
+              Click <a href="https://example.com">here</a> for more.
+            </p>
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should close bold markers at end of line`() = runTest {
+        // given
+        val parser = DefaultMarkanywhereParser()
+        val textFlow = """
+            This is **bold**
+        """.trimIndent().chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse(parser)
+
+        // then
+        parsed.render() sameAs """
+            <p>
+              This is <strong>bold</strong>
+            </p>
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should close italic markers at end of line`() = runTest {
+        // given
+        val parser = DefaultMarkanywhereParser()
+        val textFlow = """
+            This is *italic*
+        """.trimIndent().chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse(parser)
+
+        // then
+        parsed.render() sameAs """
+            <p>
+              This is <em>italic</em>
+            </p>
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should close strikethrough markers at end of line`() = runTest {
+        // given
+        val parser = DefaultMarkanywhereParser()
+        val textFlow = """
+            This is ~~deleted~~
+        """.trimIndent().chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse(parser)
+
+        // then
+        parsed.render() sameAs """
+            <p>
+              This is <del>deleted</del>
+            </p>
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should close bold italic markers at end of line`() = runTest {
+        // given
+        val parser = DefaultMarkanywhereParser()
+        val textFlow = """
+            This is ***bold italic***
+        """.trimIndent().chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse(parser)
+
+        // then
+        parsed.render() sameAs """
+            <p>
+              This is <strong><em>bold italic</em></strong>
+            </p>
+        """.trimIndent()
     }
 
 }


### PR DESCRIPTION
Fixes #25

## Changes

**Bug 1: Inline HTML not rendered** — Added `tryEmitInlineHtmlTag()` to parse inline HTML tags as semantic Mark/Unmark events. HTML tags are distinguished from comparison operators by requiring the tag name to start immediately after `<` (no leading whitespace). Reordered autolink checks so HTML is tried first.

**Bug 2: Trailing asterisks displayed** — Fixed `flushInline()` to discard trailing closing formatting markers (e.g. the `**` in `**bold**` at end of line) instead of emitting them as literal text.

Generated with [Claude Code](https://claude.ai/code)