### PR TITLE
Add streaming YAML/TOML front matter auto-detection

### DIFF
--- a/markanywhere-parse/src/commonMain/kotlin/FrontMatterFilter.kt
+++ b/markanywhere-parse/src/commonMain/kotlin/FrontMatterFilter.kt
@@ -167,7 +167,7 @@ internal class FrontMatterFilter(
         }
         if (start > 0) {
             directDownstream.emit(SemanticEvent.Text(body.substring(0, start)))
-            body.delete(0, start)
+            body.deleteRange(0, start)
         }
     }
 

--- a/markanywhere-parse/src/commonMain/kotlin/FrontMatterFilter.kt
+++ b/markanywhere-parse/src/commonMain/kotlin/FrontMatterFilter.kt
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2026 Kazimierz Pogoda / Xemantic
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.xemantic.markanywhere.parse
+
+import com.xemantic.markanywhere.SemanticEvent
+import kotlinx.coroutines.flow.FlowCollector
+
+/**
+ * Streaming auto-detection of YAML / TOML front matter at the start of the
+ * document.
+ *
+ * Sits between the input chunk flow and the regular Markdown parser:
+ *
+ * - Buffers chars until enough is seen to decide (line 1 + line 2, or EOF).
+ * - **Trigger**: line 1 is exactly `---` (YAML) or `+++` (TOML), and line 2
+ *   matches a strict discriminator that almost no natural-language paragraph
+ *   does (an identifier-then-colon for YAML, an identifier-then-equals or
+ *   `[section]` header for TOML). The discriminator is what disambiguates a
+ *   real front matter from a `---` thematic break followed by prose.
+ * - **On hit**: emits an untagged `mark("frontmatter", format=...)` directly
+ *   to the downstream collector (bypassing the parser's autolink stage,
+ *   since body content is opaque), streams body lines as `text` events
+ *   preserving `\n`, drops the closer line, and emits `unmark`. Anything
+ *   after the closer is forwarded into the regular parser as a fresh stream.
+ * - **On miss**: replays the full buffered prelude into the regular parser
+ *   and switches to pass-through.
+ * - **On EOF without a closer** (after a hit): force-closes the open
+ *   `frontmatter` mark. This mirrors how unmatched code-span openers behave
+ *   — the streaming invariant forbids retracting an emitted `mark`.
+ */
+internal class FrontMatterFilter(
+    private val directDownstream: FlowCollector<SemanticEvent>,
+    private val processInner: suspend (String) -> Unit
+) {
+
+    private enum class Mode { Detecting, InBody, AfterClose }
+
+    private var mode: Mode = Mode.Detecting
+    private val prelude = StringBuilder()
+    private val body = StringBuilder()
+    private var format: String = ""
+    private var closerLine: String = ""
+
+    suspend fun feed(chunk: String) {
+        when (mode) {
+            Detecting -> {
+                prelude.append(chunk)
+                tryDecide(eof = false)
+            }
+            InBody -> {
+                body.append(chunk)
+                drainBodyToCloser()
+            }
+            AfterClose -> processInner(chunk)
+        }
+    }
+
+    suspend fun finalize() {
+        if (mode == Mode.Detecting) {
+            tryDecide(eof = true)
+            if (mode == Mode.Detecting && prelude.isNotEmpty()) {
+                processInner(prelude.toString())
+                prelude.clear()
+                mode = Mode.AfterClose
+            }
+        }
+        if (mode == Mode.InBody) {
+            finalizeInBody()
+        }
+    }
+
+    private suspend fun tryDecide(eof: Boolean) {
+        if (prelude.isEmpty()) return
+        val first = prelude[0]
+        if (first != '-' && first != '+') {
+            replayPreludeAsContent()
+            return
+        }
+        // Verify chars seen so far match "---\n" or "+++\n" prefix.
+        val expected = if (first == '-') "---\n" else "+++\n"
+        val seen = minOf(prelude.length, 4)
+        for (i in 0 until seen) {
+            if (prelude[i] != expected[i]) {
+                replayPreludeAsContent()
+                return
+            }
+        }
+        // Not enough chars yet to confirm the opener line itself.
+        if (prelude.length < 4) {
+            if (eof) replayPreludeAsContent()
+            return
+        }
+        val opener = if (first == '-') "---" else "+++"
+        val fmt = if (first == '-') "yaml" else "toml"
+
+        // Examine line 2 (everything after the opener `\n` until next `\n`/EOF).
+        val line2Start = 4
+        val nl2 = prelude.indexOf('\n', line2Start)
+        val line2: String = when {
+            nl2 >= 0 -> prelude.substring(line2Start, nl2)
+            eof -> prelude.substring(line2Start)
+            else -> return  // wait for more chars
+        }
+        if (!discriminatorMatches(line2, fmt)) {
+            replayPreludeAsContent()
+            return
+        }
+
+        // Open front matter.
+        format = fmt
+        closerLine = opener
+        directDownstream.emit(
+            SemanticEvent.Mark(
+                name = FRONTMATTER,
+                isTagged = false,
+                attributes = mapOf("format" to fmt)
+            )
+        )
+        body.append(prelude, line2Start, prelude.length)
+        prelude.clear()
+        mode = Mode.InBody
+        drainBodyToCloser()
+    }
+
+    private suspend fun replayPreludeAsContent() {
+        if (prelude.isNotEmpty()) {
+            processInner(prelude.toString())
+            prelude.clear()
+        }
+        mode = Mode.AfterClose
+    }
+
+    private suspend fun drainBodyToCloser() {
+        var start = 0
+        while (true) {
+            val nl = body.indexOf('\n', start)
+            if (nl < 0) break
+            val line = body.substring(start, nl)
+            if (line == closerLine) {
+                if (start > 0) {
+                    directDownstream.emit(SemanticEvent.Text(body.substring(0, start)))
+                }
+                directDownstream.emit(
+                    SemanticEvent.Unmark(name = FRONTMATTER, isTagged = false)
+                )
+                val rest = body.substring(nl + 1)
+                body.clear()
+                mode = Mode.AfterClose
+                if (rest.isNotEmpty()) processInner(rest)
+                return
+            }
+            start = nl + 1
+        }
+        if (start > 0) {
+            directDownstream.emit(SemanticEvent.Text(body.substring(0, start)))
+            body.delete(0, start)
+        }
+    }
+
+    private suspend fun finalizeInBody() {
+        val residual = body.toString()
+        if (residual != closerLine && residual.isNotEmpty()) {
+            directDownstream.emit(SemanticEvent.Text(residual))
+        }
+        body.clear()
+        directDownstream.emit(
+            SemanticEvent.Unmark(name = FRONTMATTER, isTagged = false)
+        )
+        mode = Mode.AfterClose
+    }
+
+    private companion object {
+        const val FRONTMATTER: String = "frontmatter"
+
+        // Strict YAML discriminator: top-level identifier followed by `:`.
+        // Catches `title:`, `_key:`, `date-published:` — the overwhelming
+        // shape of real-world YAML front-matter first keys.
+        val YAML_KEY = Regex("""^[A-Za-z_][A-Za-z0-9_-]*\s*:""")
+
+        // Strict TOML discriminator: a `[section]` / `[[array]]` header,
+        // or an identifier followed by `=` (`key = value`).
+        val TOML_KEY_OR_SECTION =
+            Regex("""^(\[.+\]|[A-Za-z_][A-Za-z0-9_-]*\s*=)""")
+
+        fun discriminatorMatches(line: String, format: String): Boolean =
+            when (format) {
+                "yaml" -> YAML_KEY.containsMatchIn(line)
+                "toml" -> TOML_KEY_OR_SECTION.containsMatchIn(line)
+                else -> false
+            }
+    }
+}

--- a/markanywhere-parse/src/commonMain/kotlin/FrontMatterFilter.kt
+++ b/markanywhere-parse/src/commonMain/kotlin/FrontMatterFilter.kt
@@ -41,6 +41,18 @@ import kotlinx.coroutines.flow.FlowCollector
  * - **On EOF without a closer** (after a hit): force-closes the open
  *   `frontmatter` mark. This mirrors how unmatched code-span openers behave
  *   — the streaming invariant forbids retracting an emitted `mark`.
+ *
+ * Line endings (`\r\n`, `\r`, `\n`) are normalized to `\n` at the entry of
+ * [feed], so opener / closer detection works regardless of source platform.
+ *
+ * **Known limitations** (matching Jekyll/Hugo behaviour):
+ * - An unindented `---` / `+++` line anywhere in the body is treated as the
+ *   closer; content that needs to contain such a line at the left margin
+ *   must indent it by at least one space.
+ * - A TOML dotted key on line 2 (`a.b = "value"`) does not match the line-2
+ *   discriminator (`.` is not in the identifier char class), so the document
+ *   silently falls back to a thematic break. Use a `[section]` header or a
+ *   plain `key = value` first for auto-detection.
  */
 internal class FrontMatterFilter(
     private val directDownstream: FlowCollector<SemanticEvent>,
@@ -55,18 +67,60 @@ internal class FrontMatterFilter(
     private var format: String = ""
     private var closerLine: String = ""
 
+    // Tracks how far into `body` we already scanned for `\n` without finding
+    // one — the resume index for the next call to `drainBodyToCloser`. Without
+    // this, a long front-matter line arriving in tiny chunks would be O(n²)
+    // (each call re-scans from index 0 looking for the same missing `\n`).
+    private var bodyScanOffset: Int = 0
+
+    // Cross-chunk `\r\n` handling: when a chunk ends with `\r`, we already
+    // emit `\n` in its place and set this flag so the next chunk's leading
+    // `\n` (the second half of the CRLF pair) is swallowed.
+    private var pendingCr: Boolean = false
+
     suspend fun feed(chunk: String) {
+        val normalized = normalizeLineEndings(chunk)
         when (mode) {
             Detecting -> {
-                prelude.append(chunk)
+                prelude.append(normalized)
                 tryDecide(eof = false)
             }
             InBody -> {
-                body.append(chunk)
+                body.append(normalized)
                 drainBodyToCloser()
             }
-            AfterClose -> processInner(chunk)
+            AfterClose -> processInner(normalized)
         }
+    }
+
+    // Normalize `\r\n` / `\r` to `\n`. Mirrors `ParserState.preprocessChunk`
+    // (which is private and runs on the AfterClose pass-through path), but
+    // we need it here for opener/closer detection too — the `Detecting` and
+    // `InBody` paths bypass `processInner` entirely.
+    private fun normalizeLineEndings(chunk: String): String {
+        if (!pendingCr && chunk.indexOf('\r') < 0) return chunk
+        val sb = StringBuilder(chunk.length)
+        var i = 0
+        if (pendingCr) {
+            pendingCr = false
+            if (chunk[0] == '\n') i++
+        }
+        while (i < chunk.length) {
+            val c = chunk[i]
+            if (c == '\r') {
+                sb.append('\n')
+                i++
+                if (i < chunk.length) {
+                    if (chunk[i] == '\n') i++
+                } else {
+                    pendingCr = true
+                }
+            } else {
+                sb.append(c)
+                i++
+            }
+        }
+        return sb.toString()
     }
 
     suspend fun finalize() {
@@ -145,34 +199,43 @@ internal class FrontMatterFilter(
     }
 
     private suspend fun drainBodyToCloser() {
-        var start = 0
+        var lineStart = 0
+        var scanFrom = bodyScanOffset
         while (true) {
-            val nl = body.indexOf('\n', start)
+            val nl = body.indexOf('\n', scanFrom)
             if (nl < 0) break
-            val line = body.substring(start, nl)
+            val line = body.substring(lineStart, nl)
             if (line == closerLine) {
-                if (start > 0) {
-                    directDownstream.emit(SemanticEvent.Text(body.substring(0, start)))
+                if (lineStart > 0) {
+                    directDownstream.emit(SemanticEvent.Text(body.substring(0, lineStart)))
                 }
                 directDownstream.emit(
                     SemanticEvent.Unmark(name = FRONTMATTER, isTagged = false)
                 )
                 val rest = body.substring(nl + 1)
                 body.clear()
+                bodyScanOffset = 0
                 mode = Mode.AfterClose
                 if (rest.isNotEmpty()) processInner(rest)
                 return
             }
-            start = nl + 1
+            lineStart = nl + 1
+            scanFrom = nl + 1
         }
-        if (start > 0) {
-            directDownstream.emit(SemanticEvent.Text(body.substring(0, start)))
-            body.deleteRange(0, start)
+        if (lineStart > 0) {
+            directDownstream.emit(SemanticEvent.Text(body.substring(0, lineStart)))
+            body.deleteRange(0, lineStart)
         }
+        // Everything currently in `body` has been scanned for `\n` with none
+        // found beyond `lineStart`; resume future scans from the new tail.
+        bodyScanOffset = body.length
     }
 
     private suspend fun finalizeInBody() {
         val residual = body.toString()
+        // A bare `---` / `+++` at EOF without a trailing `\n` is treated as
+        // the structural closer arriving without its terminator — drop it
+        // rather than emit it as body text.
         if (residual != closerLine && residual.isNotEmpty()) {
             directDownstream.emit(SemanticEvent.Text(residual))
         }

--- a/markanywhere-parse/src/commonMain/kotlin/MarkanywhereParser.kt
+++ b/markanywhere-parse/src/commonMain/kotlin/MarkanywhereParser.kt
@@ -23,13 +23,19 @@ import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.flow
 
 public fun Flow<String>.parse(): Flow<SemanticEvent> = flow {
-    val autolinker = AutolinkCollector(this)
+    val outer: FlowCollector<SemanticEvent> = this
+    val autolinker = AutolinkCollector(outer)
     val redirector = RedirectingCollector(autolinker)
     val state = ParserState(
         scope = SemanticEventScope(collector = redirector),
         redirector = redirector
     )
-    collect { chunk -> state.processChunk(chunk) }
+    val frontMatter = FrontMatterFilter(
+        directDownstream = outer,
+        processInner = { chunk -> state.processChunk(chunk) }
+    )
+    collect { chunk -> frontMatter.feed(chunk) }
+    frontMatter.finalize()
     state.finalize()
     autolinker.finalize()
 }

--- a/markanywhere-parse/src/commonTest/kotlin/FrontMatterTest.kt
+++ b/markanywhere-parse/src/commonTest/kotlin/FrontMatterTest.kt
@@ -409,4 +409,25 @@ class FrontMatterTest {
             "p" { +"After." }
         }
     }
+
+    @Test
+    fun `should not treat dashes with trailing space as closer`() = runTest {
+        // given — closer comparison is byte-exact (matches Jekyll/Hugo). A
+        // `--- ` line with a trailing space is body content, not the closer.
+        // Explicit concatenation guards against editor auto-strip of the
+        // trailing space in the source.
+        val source = "---\ntitle: test\n--- \nstill body\n---\nAfter."
+        val textFlow = source.chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            "frontmatter"("format" to "yaml") {
+                +"title: test\n--- \nstill body\n"
+            }
+            "p" { +"After." }
+        }
+    }
 }

--- a/markanywhere-parse/src/commonTest/kotlin/FrontMatterTest.kt
+++ b/markanywhere-parse/src/commonTest/kotlin/FrontMatterTest.kt
@@ -329,4 +329,84 @@ class FrontMatterTest {
             "p" { +"Body." }
         }
     }
+
+    @Test
+    fun `should parse YAML front matter with CRLF line endings`() = runTest {
+        // given — a Windows-formatted document. `\r\n` must normalize to `\n`
+        // so opener / closer line-equality comparisons still work.
+        val textFlow =
+            "---\r\ntitle: Hello\r\nauthor: Alice\r\n---\r\nBody paragraph."
+                .chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            "frontmatter"("format" to "yaml") {
+                +"title: Hello\nauthor: Alice\n"
+            }
+            "p" { +"Body paragraph." }
+        }
+    }
+
+    @Test
+    fun `should treat bare opener without trailing newline as thematic break`() = runTest {
+        // given — a document consisting solely of `---` (no `\n`). The opener
+        // never completes, so at EOF the prelude replays as content and the
+        // regular parser emits a thematic break.
+        val textFlow = listOf("---").asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            "hr" {}
+        }
+    }
+
+    @Test
+    fun `should close front matter when closer at EOF has no trailing newline`() = runTest {
+        // given — closer arrives without a terminating `\n`. The `finalizeInBody`
+        // residual guard treats a bare `---` / `+++` at EOF as the structural
+        // close, dropping it instead of emitting it as body text.
+        val textFlow =
+            "---\ntitle: Hello\n---".chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            "frontmatter"("format" to "yaml") {
+                +"title: Hello\n"
+            }
+        }
+    }
+
+    @Test
+    fun `should not treat four-dash line in body as closer`() = runTest {
+        // given — closer comparison is exact line equality, so `----` (or any
+        // longer dash run) inside the body is content, not the closer.
+        val textFlow = """
+            ---
+            title: test
+            ----
+            still body
+            ---
+            After.
+        """.trimIndent().chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            "frontmatter"("format" to "yaml") {
+                +"title: test\n----\nstill body\n"
+            }
+            "p" { +"After." }
+        }
+    }
 }

--- a/markanywhere-parse/src/commonTest/kotlin/FrontMatterTest.kt
+++ b/markanywhere-parse/src/commonTest/kotlin/FrontMatterTest.kt
@@ -1,0 +1,332 @@
+/*
+ * Copyright 2026 Kazimierz Pogoda / Xemantic
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.xemantic.markanywhere.parse
+
+import com.xemantic.kotlin.test.text.chunkedRandomly
+import com.xemantic.markanywhere.flow.mergeAdjacentText
+import com.xemantic.markanywhere.flow.semanticEvents
+import com.xemantic.markanywhere.test.sameAs
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+/**
+ * Specifies streaming front matter recognition.
+ *
+ * Front matter is **auto-detected**: a document that begins with `---`
+ * (YAML) or `+++` (TOML) at byte 0, followed by a line-2 line that matches
+ * a strict key-pattern discriminator, opens a `frontmatter` block. The
+ * discriminator is what disqualifies a legitimate `---` thematic break
+ * followed by a paragraph or any other Markdown structure.
+ *
+ * - YAML line 2 must match `^[A-Za-z_][A-Za-z0-9_-]*\s*:` (e.g. `title:`).
+ * - TOML line 2 must match `^\[.+\]` or `^[A-Za-z_][A-Za-z0-9_-]*\s*=`
+ *   (a table header `[section]` or a `key = value` assignment).
+ *
+ * The block emits an **untagged** `frontmatter` mark/unmark pair carrying
+ * a `format` attribute (`yaml` or `toml`), with body content delivered as
+ * raw `text` events between them. Body line terminators (`\n`) are
+ * preserved; the closer line itself is consumed structurally and emits
+ * no text.
+ */
+class FrontMatterTest {
+
+    @Test
+    fun `should parse YAML front matter at document start`() = runTest {
+        // given
+        val textFlow = """
+            ---
+            title: Hello
+            author: Alice
+            ---
+            # Heading
+
+            Body paragraph.
+        """.trimIndent().chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            "frontmatter"("format" to "yaml") {
+                +"title: Hello\nauthor: Alice\n"
+            }
+            "h1" { +"Heading" }
+            "p" { +"Body paragraph." }
+        }
+    }
+
+    @Test
+    fun `should parse TOML front matter at document start`() = runTest {
+        // given
+        val textFlow = """
+            +++
+            title = "Hello"
+            author = "Alice"
+            +++
+            Body paragraph.
+        """.trimIndent().chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            "frontmatter"("format" to "toml") {
+                +"title = \"Hello\"\nauthor = \"Alice\"\n"
+            }
+            "p" { +"Body paragraph." }
+        }
+    }
+
+    @Test
+    fun `should parse TOML front matter opening with a section header`() = runTest {
+        // given
+        val textFlow = """
+            +++
+            [package]
+            name = "markanywhere"
+            +++
+            Body.
+        """.trimIndent().chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            "frontmatter"("format" to "toml") {
+                +"[package]\nname = \"markanywhere\"\n"
+            }
+            "p" { +"Body." }
+        }
+    }
+
+    @Test
+    fun `should parse front matter as the entire document`() = runTest {
+        // given
+        val textFlow = """
+            ---
+            title: Standalone
+            ---
+        """.trimIndent().chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            "frontmatter"("format" to "yaml") {
+                +"title: Standalone\n"
+            }
+        }
+    }
+
+    @Test
+    fun `should not interpret Markdown syntax inside front matter body`() = runTest {
+        // given
+        val textFlow = """
+            ---
+            title: "**Bold** _and_ # Hash"
+            list:
+              - one
+              - two
+            ---
+            # Real Heading
+        """.trimIndent().chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            "frontmatter"("format" to "yaml") {
+                +"title: \"**Bold** _and_ # Hash\"\nlist:\n  - one\n  - two\n"
+            }
+            "h1" { +"Real Heading" }
+        }
+    }
+
+    @Test
+    fun `should preserve blank lines inside front matter body`() = runTest {
+        // given
+        val textFlow = """
+            ---
+            title: With blanks
+
+            description: |
+              first
+
+              second
+            ---
+            Body.
+        """.trimIndent().chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            "frontmatter"("format" to "yaml") {
+                +"title: With blanks\n\ndescription: |\n  first\n\n  second\n"
+            }
+            "p" { +"Body." }
+        }
+    }
+
+    @Test
+    fun `should not treat fenced-code-like body content as a code block`() = runTest {
+        // given — triple backticks inside front matter must NOT open a fence;
+        // body parsing is opaque, line-by-line until the closer.
+        val textFlow = """
+            ---
+            content: |
+              ```
+              not-a-fence
+              ```
+            ---
+            Body.
+        """.trimIndent().chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            "frontmatter"("format" to "yaml") {
+                +"content: |\n  ```\n  not-a-fence\n  ```\n"
+            }
+            "p" { +"Body." }
+        }
+    }
+
+    @Test
+    fun `should DIVERGENCE auto-close unterminated front matter at EOF`() = runTest {
+        // given — opener but no closer. DIVERGENCE: spec-correct behavior would
+        // require buffering the whole document to detect the missing closer
+        // and fall back to a thematic break + paragraphs. The streaming parser
+        // commits the `frontmatter` open mark eagerly and force-closes at
+        // finalize, mirroring how unmatched code-span openers behave.
+        val textFlow = """
+            ---
+            title: Forgotten
+            # This still flows into front matter because no closer arrived.
+        """.trimIndent().chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            "frontmatter"("format" to "yaml") {
+                +"title: Forgotten\n# This still flows into front matter because no closer arrived."
+            }
+        }
+    }
+
+    @Test
+    fun `should not auto-detect front matter when line 2 is not key-like`() = runTest {
+        // given — `---` followed by a natural-language paragraph fails the
+        // YAML discriminator, so the opener is treated as a thematic break.
+        val textFlow = """
+            ---
+            This is just a paragraph.
+            ---
+            Body.
+        """.trimIndent().chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then — both `---` lines are thematic breaks (the parser does not
+        // implement setext headings — DIVERGENCE), with paragraphs around them.
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            "hr" {}
+            "p" { +"This is just a paragraph." }
+            "hr" {}
+            "p" { +"Body." }
+        }
+    }
+
+    @Test
+    fun `should not auto-detect front matter when line 2 is another dashes line`() = runTest {
+        // given — `---` followed by another `---` is two thematic breaks,
+        // not empty front matter. Empty front matter has no real-world use
+        // and conflicts with the more common double-thematic-break case.
+        val textFlow = """
+            ---
+            ---
+            Body.
+        """.trimIndent().chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            "hr" {}
+            "hr" {}
+            "p" { +"Body." }
+        }
+    }
+
+    @Test
+    fun `should not recognise front matter when opener is preceded by content`() = runTest {
+        // given — a leading paragraph means line 1 is not the opener; the
+        // `---` on line 2 is a thematic break (the parser does not implement
+        // setext headings — DIVERGENCE).
+        val textFlow = """
+            title
+            ---
+            Body.
+        """.trimIndent().chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            "p" { +"title" }
+            "hr" {}
+            "p" { +"Body." }
+        }
+    }
+
+    @Test
+    fun `should not recognise front matter mid-document after a heading`() = runTest {
+        // given — front matter only triggers at byte 0; a `---` after a heading
+        // is a thematic break under default GFM rules.
+        val textFlow = """
+            # Heading
+
+            ---
+
+            Body.
+        """.trimIndent().chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            "h1" { +"Heading" }
+            "hr" {}
+            "p" { +"Body." }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Auto-detects YAML (`---`) and TOML (`+++`) front matter at byte 0, gated by a strict line-2 key-pattern discriminator that disqualifies natural-language paragraphs and avoids stealing legitimate `---` thematic breaks.
- Emits an untagged `frontmatter` mark/unmark pair with a `format` attribute (`yaml` or `toml`); body content streams as raw text events with line terminators preserved, so consumers can parse the chosen dialect themselves.
- New `FrontMatterFilter` sits between the input chunk flow and the regular Markdown parser, bypassing the autolink stage for body content. Unterminated openers force-close at EOF (DIVERGENCE — consistent with the streaming append-only invariant; mirrors how unmatched code-span openers behave).

## Test plan
- [ ] `:markanywhere-parse:jvmTest --tests FrontMatterTest`
- [ ] Full `:markanywhere-parse:jvmTest` to confirm no regressions in existing GFM coverage
- [ ] Verify chunked input across random boundaries still produces identical events (covered by `chunkedRandomly()` in tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)