### PR TITLE
Harden HTML block parsing against real-world HTML

### DIFF
--- a/markanywhere-parse/src/commonMain/kotlin/AutolinkCollector.kt
+++ b/markanywhere-parse/src/commonMain/kotlin/AutolinkCollector.kt
@@ -17,6 +17,7 @@
 package com.xemantic.markanywhere.parse
 
 import com.xemantic.markanywhere.SemanticEvent
+import com.xemantic.markanywhere.parse.AutolinkCollector.Companion.SUPPRESS_NAMES
 import kotlinx.coroutines.flow.FlowCollector
 
 /**
@@ -67,10 +68,22 @@ internal class AutolinkCollector(
      */
     private var suppressDepth = 0
 
+    /**
+     * Suppression depth for HTML block 6/7 raw-text streaming (CommonMark
+     * §4.6). Disallowed tags (§6.11) like `<style>` and `<script>` inside
+     * such blocks are filtered by `tokenizeHtmlLine` and reach this collector
+     * as plain text — no enclosing `mark`/`unmark` is emitted, so the
+     * standard [suppressDepth] mechanism never activates. The parser
+     * increments [htmlRawTextDepth] on entry to an opening-tag-rooted
+     * HTML 6/7 frame's raw-text phase, and decrements on exit (root close,
+     * transition to sub-parse on blank line, or finalize cleanup).
+     */
+    var htmlRawTextDepth: Int = 0
+
     override suspend fun emit(value: SemanticEvent) {
         when (value) {
             is SemanticEvent.Text -> {
-                if (suppressDepth > 0) {
+                if (suppressDepth > 0 || htmlRawTextDepth > 0) {
                     drain()
                     charBeforeWord = null
                     downstream.emit(value)
@@ -125,7 +138,7 @@ internal class AutolinkCollector(
 
         var pos = 0
         for (span in spans) {
-            emitRange(events, starts, full, pos, span.urlStart)
+            emitRange(events, starts, pos, span.urlStart)
             downstream.emit(
                 SemanticEvent.Mark(
                     name = "a",
@@ -136,20 +149,19 @@ internal class AutolinkCollector(
             downstream.emit(SemanticEvent.Unmark(name = "a"))
             pos = span.urlEnd
         }
-        emitRange(events, starts, full, pos, full.length)
+        emitRange(events, starts, pos, full.length)
         if (full.isNotEmpty()) charBeforeWord = full.last()
     }
 
     /**
-     * Emit the text range `[from, to)` of [full] downstream, preserving
-     * the original event shapes from [events]: a fully covered event is
-     * emitted as-is (re-using the event instance); a partial cover emits
-     * a fresh `Text` with the substring.
+     * Emit the concatenated-buffer range `[from, to)` downstream, preserving
+     * the original event shapes from [events] (located via [starts]): a fully
+     * covered event is emitted as-is (re-using the event instance); a partial
+     * cover emits a fresh `Text` with the substring.
      */
     private suspend fun emitRange(
         events: List<SemanticEvent.Text>,
         starts: IntArray,
-        full: String,
         from: Int,
         to: Int
     ) {
@@ -389,7 +401,6 @@ private fun scanEmail(s: String, start: Int): String? {
     val atIdx = i
     if (s[atIdx - 1] == '.') return null  // local-part can't end with `.`
     i++
-    val domainStart = i
     val segments = mutableListOf<IntRange>()
     var segStart = i
     while (i < s.length) {
@@ -411,7 +422,7 @@ private fun scanEmail(s: String, start: Int): String? {
     if (segments.size < 2) return null
     for ((idx, range) in segments.withIndex()) {
         val len = range.last - range.first + 1
-        if (len < 1 || len > 63) return null
+        if (len !in 1..63) return null
         val first = s[range.first]
         val last = s[range.last]
         if (first == '-' || last == '-') return null
@@ -420,7 +431,6 @@ private fun scanEmail(s: String, start: Int): String? {
             for (k in range) if (s[k] == '_') return null
         }
     }
-    if (domainStart >= s.length || !s[domainStart].isDomainSegmentChar()) return null
     val emailEnd = segments.last().last + 1
     return s.substring(start, emailEnd)
 }

--- a/markanywhere-parse/src/commonMain/kotlin/MarkanywhereParser.kt
+++ b/markanywhere-parse/src/commonMain/kotlin/MarkanywhereParser.kt
@@ -28,7 +28,8 @@ public fun Flow<String>.parse(): Flow<SemanticEvent> = flow {
     val redirector = RedirectingCollector(autolinker)
     val state = ParserState(
         scope = SemanticEventScope(collector = redirector),
-        redirector = redirector
+        redirector = redirector,
+        autolinker = autolinker
     )
     val frontMatter = FrontMatterFilter(
         directDownstream = outer,
@@ -725,6 +726,22 @@ private fun normalizeHtmlName(name: String): String {
     return if (lower in HTML5_ELEMENTS) lower else name
 }
 
+/**
+ * HTML5 void elements (no content, no closing tag — always treated as
+ * self-closing). Real-world HTML omits `/>` on these (`<meta charset="…">`
+ * not `<meta charset="…"/>`), so the parser must auto-close them on `mark`
+ * to keep the event stream balanced. Names compared case-insensitively
+ * after lowering.
+ */
+private val HTML5_VOID_ELEMENTS: Set<String> = setOf(
+    "area", "base", "br", "col", "embed", "hr", "img", "input",
+    "keygen", "link", "meta", "param", "source", "track", "wbr"
+)
+
+/** True when this open tag must auto-emit `unmark` immediately. */
+private fun HtmlToken.OpenTag.isSelfClosingOrVoid(): Boolean =
+    selfClosing || name.lowercase() in HTML5_VOID_ELEMENTS
+
 private sealed interface HtmlToken {
     data class OpenTag(
         val name: String,
@@ -849,14 +866,29 @@ private fun tokenizeHtmlLine(line: String): List<HtmlToken> {
         if (line[i] == '<') {
             val open = tryParseOpenTag(line, i)
             if (open != null) {
-                if (open.second.name.lowercase() in GFM_DISALLOWED_TAGS) {
-                    // GFM §6.11: emit the source as text instead of a tag.
-                    text.append(line, i, open.first)
+                val openLower = open.second.name.lowercase()
+                if (openLower in GFM_DISALLOWED_TAGS) {
+                    // GFM §6.11: the disallowed tag itself becomes literal text.
+                    // Additionally — to keep the body opaque to HTML detection
+                    // (a `<script>var s = "<a>"` shape must not open a nested
+                    // `<a>` mark) — scan ahead on this line for the matching
+                    // `</name>`. If found, the whole span (open + body + close)
+                    // emits as one text run. If not (multi-line shape), only the
+                    // opener is text — subsequent lines flow back through normal
+                    // tokenization. The multi-line case is left to a follow-up.
+                    val matchEnd = findDisallowedCloseOnLine(line, open.first, openLower)
+                    if (matchEnd >= 0) {
+                        text.append(line, i, matchEnd)
+                        i = matchEnd
+                    } else {
+                        text.append(line, i, open.first)
+                        i = open.first
+                    }
                 } else {
                     flushText()
                     tokens.add(open.second)
+                    i = open.first
                 }
-                i = open.first
                 continue
             }
             val close = tryParseCloseTag(line, i)
@@ -876,6 +908,37 @@ private fun tokenizeHtmlLine(line: String): List<HtmlToken> {
     }
     flushText()
     return tokens
+}
+
+/**
+ * Find the end index (past `>`) of `</[lowerName]>` in [line] starting at
+ * [startIdx], with optional whitespace before the `>`. Returns -1 if no
+ * such close tag appears on the line. Used by [tokenizeHtmlLine] to make
+ * the body of a GFM §6.11 disallowed tag opaque on a single line.
+ */
+private fun findDisallowedCloseOnLine(
+    line: String,
+    startIdx: Int,
+    lowerName: String
+): Int {
+    val pattern = "</$lowerName"
+    val lower = line.lowercase()
+    var idx = lower.indexOf(pattern, startIdx)
+    while (idx >= 0) {
+        val afterName = idx + pattern.length
+        // The char after `</name` must be whitespace or `>` so we don't match
+        // a prefix like `</scripty>` against `script`.
+        if (afterName < line.length) {
+            val c = line[afterName]
+            if (c == '>' || c == ' ' || c == '\t') {
+                var j = afterName
+                while (j < line.length && (line[j] == ' ' || line[j] == '\t')) j++
+                if (j < line.length && line[j] == '>') return j + 1
+            }
+        }
+        idx = lower.indexOf(pattern, idx + 1)
+    }
+    return -1
 }
 
 /**
@@ -952,7 +1015,8 @@ private fun isCompleteHtmlTagLine(trimmed: String): Boolean {
 
 private class ParserState(
     private val scope: SemanticEventScope,
-    private val redirector: RedirectingCollector
+    private val redirector: RedirectingCollector,
+    private val autolinker: AutolinkCollector
 ) {
 
     // Block modes
@@ -2979,18 +3043,12 @@ private class ParserState(
                     is HtmlToken.Text -> text.append(tok.content)
                     is HtmlToken.CloseTag -> {
                         if (text.isNotEmpty()) { +text.toString(); text.clear() }
-                        val tokLower = tok.name.lowercase()
-                        if (state.openTags.isNotEmpty() &&
-                            state.openTags.last().lowercase() == tokLower
-                        ) {
-                            state.openTags.removeLast()
-                        }
-                        unmarkHtml(tok.name)
+                        emitMatchingClose(tok.name, state.openTags)
                     }
                     is HtmlToken.OpenTag -> {
                         if (text.isNotEmpty()) { +text.toString(); text.clear() }
                         markHtml(tok.name, tok.attributes)
-                        if (tok.selfClosing) unmarkHtml(tok.name)
+                        if (tok.isSelfClosingOrVoid()) unmarkHtml(tok.name)
                         else state.openTags.add(normalizeHtmlName(tok.name))
                     }
                 }
@@ -3106,7 +3164,7 @@ private class ParserState(
         while (idx < source.length && source[idx] == '<') {
             val nextOpen = tryParseOpenTag(source, idx) ?: break
             markHtml(nextOpen.second.name, nextOpen.second.attributes)
-            if (nextOpen.second.selfClosing) {
+            if (nextOpen.second.isSelfClosingOrVoid()) {
                 unmarkHtml(nextOpen.second.name)
             } else {
                 state.openTags.add(normalizeHtmlName(nextOpen.second.name))
@@ -3142,18 +3200,12 @@ private class ParserState(
                 is HtmlToken.OpenTag -> {
                     flushPending()
                     markHtml(tok.name, tok.attributes)
-                    if (tok.selfClosing) unmarkHtml(tok.name)
+                    if (tok.isSelfClosingOrVoid()) unmarkHtml(tok.name)
                     else state.openTags.add(normalizeHtmlName(tok.name))
                 }
                 is HtmlToken.CloseTag -> {
                     flushPending()
-                    val tokLower = tok.name.lowercase()
-                    if (state.openTags.isNotEmpty() &&
-                        state.openTags.last().lowercase() == tokLower
-                    ) {
-                        state.openTags.removeLast()
-                    }
-                    unmarkHtml(tok.name)
+                    emitMatchingClose(tok.name, state.openTags)
                 }
             }
         }
@@ -4611,6 +4663,29 @@ private class ParserState(
     }
 
     /**
+     * Emit balanced close events for the HTML close tag named [closeName],
+     * draining [openTags] LIFO down to (and including) the deepest matching
+     * open. If no match is found, the close is **dropped silently** — per
+     * the HTML5 parser spec ("an end tag whose tag name is not in the stack
+     * of open elements is a parse error; ignore the token"), this keeps the
+     * downstream event stream balanced for the common real-world case where
+     * source HTML has stray closes that don't pair with anything on the
+     * current frame's open stack.
+     */
+    private suspend fun SemanticEventScope.emitMatchingClose(
+        closeName: String,
+        openTags: MutableList<String>
+    ) {
+        val lower = closeName.lowercase()
+        val matchIdx = openTags.indexOfLast { it.lowercase() == lower }
+        if (matchIdx < 0) return
+        while (openTags.size > matchIdx + 1) {
+            unmarkHtml(openTags.removeLast())
+        }
+        unmarkHtml(openTags.removeLast())
+    }
+
+    /**
      * Enter an HTML block (CommonMark 4.6) given the first source line (already buffered).
      * Dispatches by detected block type and seeds the per-type state.
      */
@@ -4653,11 +4728,31 @@ private class ParserState(
                 // may push a fresh `Start` frame on top, and the matching root close
                 // tag pops back to whatever was underneath.
                 pushMode(mode)
+                // Opening-tag root enters raw-text streaming — suppress extended
+                // autolinks until raw-text exits (close / sub-parse transition).
+                // See [leaveRawHtmlBlock] for the matching decrement.
+                if (!isClose) autolinker.htmlRawTextDepth++
                 // Buffer the first line into firstLineBuffer for tag-completion checks.
                 mode.firstLineBuffer!!.append(line)
                 tryFinishHtmlBlock6or7FirstLine(mode)
             }
             else -> +"$line\n"
+        }
+    }
+
+    /**
+     * Decrement [autolinker]'s HTML raw-text suppression counter when an
+     * opening-tag-rooted [BlockMode.HtmlBlock6or7] frame leaves its raw-text
+     * phase — by closing, by transitioning to sub-parse on a blank line, or
+     * by finalize/EOF cleanup. Idempotent: uses [BlockMode.ChildMode.SubParse]
+     * as a sentinel so callers may invoke at any exit point without tracking
+     * which transition already fired.
+     */
+    private fun leaveRawHtmlBlock(mode: BlockMode.HtmlBlock6or7) {
+        if (mode.rootIsClosingTag) return
+        if (mode.childMode == BlockMode.ChildMode.RawText) {
+            autolinker.htmlRawTextDepth--
+            mode.childMode = BlockMode.ChildMode.SubParse
         }
     }
 
@@ -4718,47 +4813,59 @@ private class ParserState(
             return
         }
         val closeEnd = i + 1
-        // Tokenize content before the root close to recognize any nested inner close tags.
+        // GFM §4.6: type-1 block bodies are raw text — open tags inside the body
+        // (`var s = "<div>foo</div>"` in `<script>`, `a::before{content:"<x>"}`
+        // in `<style>`) must NOT open nested marks. But the opener-chain
+        // mechanism in [tryFinishHtmlBlock1FirstLine] does open contiguous tags
+        // (e.g. `<pre><code>`), so we still recognise close tags inside the body
+        // that match the current top of `mode.openTags` and pop them at the
+        // right position. Non-matching closes and any open tags inside the body
+        // pass through as literal text.
         val before = line.substring(0, closeIndex)
         if (before.isNotEmpty()) {
-            val beforeTokens = tokenizeHtmlLine(before)
-            val text = StringBuilder()
-            for (tok in beforeTokens) {
-                when (tok) {
-                    is HtmlToken.Text -> text.append(tok.content)
-                    is HtmlToken.CloseTag -> {
-                        if (text.isNotEmpty()) { +text.toString(); text.clear() }
-                        val tokLower = tok.name.lowercase()
-                        if (mode.openTags.isNotEmpty() &&
-                            mode.openTags.last().lowercase() == tokLower
-                        ) {
-                            mode.openTags.removeLast()
+            val pendingText = StringBuilder()
+            var j = 0
+            while (j < before.length) {
+                if (before[j] == '<') {
+                    val tokClose = tryParseCloseTag(before, j)
+                    if (tokClose != null && mode.openTags.isNotEmpty() &&
+                        mode.openTags.last().lowercase() == tokClose.second.name.lowercase()
+                    ) {
+                        if (pendingText.isNotEmpty()) {
+                            +pendingText.toString(); pendingText.clear()
                         }
-                        unmarkHtml(tok.name)
-                    }
-                    is HtmlToken.OpenTag -> {
-                        if (text.isNotEmpty()) { +text.toString(); text.clear() }
-                        markHtml(tok.name, tok.attributes)
-                        if (tok.selfClosing) unmarkHtml(tok.name)
-                        else mode.openTags.add(normalizeHtmlName(tok.name))
+                        mode.openTags.removeLast()
+                        unmarkHtml(tokClose.second.name)
+                        j = tokClose.first
+                        continue
                     }
                 }
+                pendingText.append(before[j])
+                j++
             }
-            if (text.isNotEmpty()) +text.toString()
+            if (pendingText.isNotEmpty()) +pendingText.toString()
         }
-        // Close any nested still-open tags then the root.
+        // Close any tags still open then the root.
         while (mode.openTags.size > 1) {
             unmarkHtml(mode.openTags.removeLast())
         }
         if (mode.openTags.isNotEmpty()) {
             unmarkHtml(mode.openTags.removeLast())
         }
-        // Trailing content after the close becomes a top-level text event with newline.
+        // Trailing content after the close: re-run HTML block detection so
+        // adjacent type-1 blocks on the same line (e.g. `</script><style>...`)
+        // open a fresh block instead of flowing as paragraph text. Non-HTML
+        // trailing content keeps the historical behaviour (emitted as a raw
+        // text event with newline — no paragraph wrapping).
         val trailing = line.substring(closeEnd)
-        if (trailing.isNotEmpty()) {
-            +"$trailing\n"
-        }
         replaceMode(BlockMode.Start)
+        if (trailing.isNotEmpty()) {
+            if (detectHtmlBlockType(trailing) > 0) {
+                enterHtmlBlock(trailing)
+            } else {
+                +"$trailing\n"
+            }
+        }
     }
 
     /**
@@ -4897,8 +5004,14 @@ private class ParserState(
         var idx = i
         while (idx < source.length && source[idx] == '<') {
             val nextOpen = tryParseOpenTag(source, idx) ?: break
+            if (nextOpen.second.name.lowercase() in GFM_DISALLOWED_TAGS) {
+                // GFM §6.11: stop the opener chain here. The disallowed tag and
+                // everything after it route through `streamHtmlBlock6or7ContentLine`,
+                // where `tokenizeHtmlLine` returns the tag source as literal text.
+                break
+            }
             markHtml(nextOpen.second.name, nextOpen.second.attributes)
-            if (nextOpen.second.selfClosing) {
+            if (nextOpen.second.isSelfClosingOrVoid()) {
                 unmarkHtml(nextOpen.second.name)
             } else {
                 mode.openTags.add(normalizeHtmlName(nextOpen.second.name))
@@ -4935,7 +5048,7 @@ private class ParserState(
             // The matching root close tag is then handled by the close-tag check
             // at the top of `processStart`'s `\n` handler.
             +"\n"
-            mode.childMode = BlockMode.ChildMode.SubParse
+            leaveRawHtmlBlock(mode)
             pushMode(BlockMode.Start)
             return
         }
@@ -4956,6 +5069,7 @@ private class ParserState(
         if (mode.openTags.isNotEmpty()) unmarkHtml(mode.openTags.removeLast())
         val trailing = line.substring(closeEnd)
         if (trailing.isNotEmpty()) +"$trailing\n"
+        leaveRawHtmlBlock(mode)
         // Pop the HTML frame; the enclosing context resumes (typically `Start`).
         popMode()
     }
@@ -4991,6 +5105,7 @@ private class ParserState(
             if (mode.openTags.isNotEmpty()) unmarkHtml(mode.openTags.removeLast())
             val trailing = line.substring(closeEnd)
             if (trailing.isNotEmpty()) +"$trailing\n"
+            leaveRawHtmlBlock(mode)
             popMode()
             return true
         }
@@ -5014,7 +5129,7 @@ private class ParserState(
             if (mode.openTags.isNotEmpty()) {
                 unmarkHtml(mode.openTags.removeLast())
             }
-            mode.childMode = BlockMode.ChildMode.SubParse
+            leaveRawHtmlBlock(mode)
             pushMode(BlockMode.Start)
             return true
         }
@@ -5043,18 +5158,12 @@ private class ParserState(
                 is HtmlToken.OpenTag -> {
                     flushPending()
                     markHtml(tok.name, tok.attributes)
-                    if (tok.selfClosing) unmarkHtml(tok.name)
+                    if (tok.isSelfClosingOrVoid()) unmarkHtml(tok.name)
                     else mode.openTags.add(normalizeHtmlName(tok.name))
                 }
                 is HtmlToken.CloseTag -> {
                     flushPending()
-                    val tokLower = tok.name.lowercase()
-                    if (mode.openTags.isNotEmpty() &&
-                        mode.openTags.last().lowercase() == tokLower
-                    ) {
-                        mode.openTags.removeLast()
-                    }
-                    unmarkHtml(tok.name)
+                    emitMatchingClose(tok.name, mode.openTags)
                 }
             }
         }
@@ -5081,18 +5190,12 @@ private class ParserState(
                 is HtmlToken.OpenTag -> {
                     flushPending()
                     markHtml(tok.name, tok.attributes)
-                    if (tok.selfClosing) unmarkHtml(tok.name)
+                    if (tok.isSelfClosingOrVoid()) unmarkHtml(tok.name)
                     else mode.openTags.add(normalizeHtmlName(tok.name))
                 }
                 is HtmlToken.CloseTag -> {
                     flushPending()
-                    val tokLower = tok.name.lowercase()
-                    if (mode.openTags.isNotEmpty() &&
-                        mode.openTags.last().lowercase() == tokLower
-                    ) {
-                        mode.openTags.removeLast()
-                    }
-                    unmarkHtml(tok.name)
+                    emitMatchingClose(tok.name, mode.openTags)
                 }
             }
         }
@@ -5514,7 +5617,7 @@ private class ParserState(
                         ) {
                             val tag = open.second
                             mark(tag.name, isTagged = true, attributes = tag.attributes)
-                            if (tag.selfClosing) {
+                            if (tag.isSelfClosingOrVoid()) {
                                 unmark(tag.name, isTagged = true)
                             } else {
                                 inlineOpenStack.addLast(InlineOpenFrame(tag.name, isTagged = true))
@@ -6816,6 +6919,7 @@ private class ParserState(
                         }
                         // Phase-1 fallback emitted the buffered opener as text; pop
                         // back to the enclosing frame.
+                        leaveRawHtmlBlock(mode)
                         popMode()
                         continue
                     }
@@ -6830,6 +6934,7 @@ private class ParserState(
                     while (mode.openTags.isNotEmpty()) {
                         unmarkHtml(mode.openTags.removeLast())
                     }
+                    leaveRawHtmlBlock(mode)
                     popMode()
                 }
             }

--- a/markanywhere-parse/src/commonTest/kotlin/HtmlParsingTest.kt
+++ b/markanywhere-parse/src/commonTest/kotlin/HtmlParsingTest.kt
@@ -71,7 +71,7 @@ class HtmlParsingTest {
      * scope (no mark was emitted) and happily wraps the URL in `<a>`.
      */
     @Test
-    fun `CSS url() inside style nested in outer HTML 6 block is not autolinked`() = runTest {
+    fun `CSS url inside style nested in outer HTML 6 block is not autolinked`() = runTest {
         // given
         val src = "<div>\n<style>@font-face{src:url(https://example.com/x.woff2)}</style>\n</div>\n"
 

--- a/markanywhere-parse/src/commonTest/kotlin/HtmlParsingTest.kt
+++ b/markanywhere-parse/src/commonTest/kotlin/HtmlParsingTest.kt
@@ -27,10 +27,7 @@ import kotlin.test.Test
  * Minimal repros for problematic places found while running the parser
  * against a real-world HTML document (BBC News front page). Each test
  * isolates one pattern where the contents of `<script>` or `<style>` (or
- * their surrounding HTML 6/7 structure) end up misinterpreted.
- *
- * All expectations below describe the **correct** behavior; expect each
- * test to currently FAIL until the corresponding bug is fixed.
+ * their surrounding HTML 6/7 structure) were previously misinterpreted.
  */
 class HtmlParsingTest {
 

--- a/markanywhere-parse/src/commonTest/kotlin/HtmlParsingTest.kt
+++ b/markanywhere-parse/src/commonTest/kotlin/HtmlParsingTest.kt
@@ -1,0 +1,328 @@
+/*
+ * Copyright 2026 Kazimierz Pogoda / Xemantic
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.xemantic.markanywhere.parse
+
+import com.xemantic.markanywhere.flow.mergeAdjacentText
+import com.xemantic.markanywhere.flow.semanticEvents
+import com.xemantic.markanywhere.test.sameAs
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+/**
+ * Minimal repros for problematic places found while running the parser
+ * against a real-world HTML document (BBC News front page). Each test
+ * isolates one pattern where the contents of `<script>` or `<style>` (or
+ * their surrounding HTML 6/7 structure) end up misinterpreted.
+ *
+ * All expectations below describe the **correct** behavior; expect each
+ * test to currently FAIL until the corresponding bug is fixed.
+ */
+class HtmlParsingTest {
+
+    /**
+     * **Place 1** — adjacent type-1 blocks on the same line.
+     *
+     * When two `<script>` / `<style>` blocks sit on the same source line
+     * (`</script><style>…</style>`), the second opener is missed entirely:
+     * the trailing portion after the first `</script>` is emitted as plain
+     * paragraph text, and [detectHtmlBlockType] is not re-run on it.
+     * Consequence: the CSS inside the dropped `<style>` flows as paragraph
+     * content and §6.9 extended autolinks fire on any `url(https://…)`.
+     */
+    @Test
+    fun `adjacent type-1 blocks on the same line - second opener detected`() = runTest {
+        // given
+        val src = "<script>a()</script><style>p{color:red}</style>\n"
+
+        // when
+        val parsed = flowOf(src).parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents(tagged = true) {
+            "script" { +"a()" }
+            "style" { +"p{color:red}" }
+        }
+    }
+
+    /**
+     * **Place 2** — CSS `url(https://…)` inside `<style>` nested in an outer
+     * HTML 6/7 block gets autolinked.
+     *
+     * Outer `<div>` opens HTML block 6. Inside, `<style>` is a GFM §6.11
+     * disallowed tag, so `tokenizeHtmlLine` returns the `<style>` /
+     * `</style>` source as `HtmlToken.Text`. The CSS body in between is
+     * also tokenized as text and then emitted through the autolink
+     * collector — which knows nothing about the surrounding `<style>`
+     * scope (no mark was emitted) and happily wraps the URL in `<a>`.
+     */
+    @Test
+    fun `CSS url() inside style nested in outer HTML 6 block is not autolinked`() = runTest {
+        // given
+        val src = "<div>\n<style>@font-face{src:url(https://example.com/x.woff2)}</style>\n</div>\n"
+
+        // when
+        val parsed = flowOf(src).parse()
+
+        // then — the URL inside the CSS must NOT generate an `<a>` mark.
+        // The `<style>` literal arrives as text (GFM §6.11), so the whole
+        // CSS line should reach the collector as a single text run.
+        parsed.mergeAdjacentText() sameAs semanticEvents(tagged = true) {
+            tag("div") {
+                +"\n<style>@font-face{src:url(https://example.com/x.woff2)}</style>\n"
+            }
+        }
+    }
+
+    /**
+     * **Place 3** — HTML-like substrings inside a `<script>` body nested
+     * in an outer HTML 6/7 block become nested marks.
+     *
+     * Same root cause as Place 2: the `<script>` source is filtered to
+     * literal text (§6.11), but the JS body in between is tokenized line
+     * by line — so a `<a>` / `<div>` in a string literal opens a mark.
+     */
+    @Test
+    fun `tags inside script body nested in outer HTML 6 block stay literal`() = runTest {
+        // given
+        val src = "<div>\n<script>var s = \"<a href='x'>hi</a>\";</script>\n</div>\n"
+
+        // when
+        val parsed = flowOf(src).parse()
+
+        // then — no `<a>` mark should appear: the script body is text.
+        parsed.mergeAdjacentText() sameAs semanticEvents(tagged = true) {
+            tag("div") {
+                +"\n<script>var s = \"<a href='x'>hi</a>\";</script>\n"
+            }
+        }
+    }
+
+    /**
+     * **Place 4** — `<title>` / `<style>` / `<script>` in the opener chain
+     * of an outer HTML 6/7 block leak through as `tagged` marks.
+     *
+     * [tryFinishHtmlBlock6or7FirstLine] walks contiguous `<…>` opens on
+     * the first line and calls `markHtml(name, attrs)` for each one
+     * without consulting [GFM_DISALLOWED_TAGS]. So `<title>` opens as a
+     * tagged mark; the following content streams through
+     * [streamHtmlBlock6or7ContentLine], which *does* filter, so the
+     * matching `</title>` arrives as literal text. The block is then
+     * unbalanced until end-of-document finalize closes it.
+     *
+     * Same lookup gap affects `<style>` and `<script>` appearing in the
+     * opener chain — i.e. exactly the BBC-style head:
+     * `<html><head><meta …><meta …><title …>Page title</title>…`.
+     */
+    @Test
+    fun `disallowed tags in HTML 6 opener chain are filtered to literal text`() = runTest {
+        // given
+        val src = "<html><head><title>Hello</title></head></html>\n"
+
+        // when
+        val parsed = flowOf(src).parse()
+
+        // then — `<title>` is a §6.11 disallowed tag: the opener should
+        // arrive as text, the content as text, and the closer as text.
+        parsed.mergeAdjacentText() sameAs semanticEvents(tagged = true) {
+            tag("html") {
+                tag("head") {
+                    +"<title>Hello</title>"
+                }
+            }
+        }
+    }
+
+    /**
+     * **Place 5** — `<` inside a top-level `<script>` body confuses the
+     * close-detection helper.
+     *
+     * [emitHtmlBlock1ContentLine] tokenizes the substring *before* the
+     * matched `</script>` with [tokenizeHtmlLine] in order to recognise
+     * nested inner close tags. That tokenizer treats any `<name …>` as a
+     * potential open tag — including occurrences inside JS string
+     * literals (`"<div>foo</div>"`) or JSX-y comparisons (`a < b`). Per
+     * GFM §4.6 the body of a type-1 block is **raw text** and must NOT
+     * be tokenized: the script body should reach the collector verbatim.
+     */
+    @Test
+    fun `tags inside top-level script body remain literal text`() = runTest {
+        // given
+        val src = "<script>var s = \"<div>hi</div>\";</script>\n"
+
+        // when
+        val parsed = flowOf(src).parse()
+
+        // then — no nested `<div>` mark/unmark should appear in the stream.
+        parsed.mergeAdjacentText() sameAs semanticEvents(tagged = true) {
+            "script" {
+                +"var s = \"<div>hi</div>\";"
+            }
+        }
+    }
+
+    /**
+     * **Place 6** — same as Place 5, but for `<style>`. CSS content like
+     * `a[href^="<"]` or `selector::before { content: "<x>" }` should pass
+     * through verbatim, never tokenized as HTML.
+     */
+    @Test
+    fun `tags inside top-level style body remain literal text`() = runTest {
+        // given
+        val src = "<style>a::before{content:\"<x>\"}</style>\n"
+
+        // when
+        val parsed = flowOf(src).parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents(tagged = true) {
+            "style" {
+                +"a::before{content:\"<x>\"}"
+            }
+        }
+    }
+
+    /**
+     * **Place 7** — HTML5 void elements (`<meta>`, `<link>`, `<img>`, `<br>`,
+     * `<hr>`, `<input>`, etc.) lack a closing tag in HTML5 source. Without
+     * auto-closing them on `mark`, the parser would leave their entries on
+     * the open-tag stack until end-of-document — producing a stream that's
+     * superficially balanced (drain in `finalize()`) but with all the void
+     * `unmark`s piled up at the very end of the output rather than at the
+     * source position.
+     */
+    @Test
+    fun `void element inside HTML 6 content auto-closes inline`() = runTest {
+        // given
+        val src = "<div>\n<meta charset=\"utf-8\">\n</div>\n"
+
+        // when
+        val parsed = flowOf(src).parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents(tagged = true) {
+            tag("div") {
+                +"\n"
+                tag("meta", "charset" to "utf-8") {}
+                +"\n"
+            }
+        }
+    }
+
+    /**
+     * **Place 8** — Same auto-close requirement applies to void elements
+     * appearing in the contiguous opener chain of an HTML 6/7 block
+     * (`<html><head><meta …><meta …>…`). The opener-chain walker must not
+     * push them onto `openTags` since no matching close tag will ever
+     * arrive.
+     */
+    @Test
+    fun `void element in HTML 6 opener chain auto-closes`() = runTest {
+        // given
+        val src = "<html><meta charset=\"utf-8\"><body>x</body></html>\n"
+
+        // when
+        val parsed = flowOf(src).parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents(tagged = true) {
+            tag("html") {
+                tag("meta", "charset" to "utf-8") {}
+                tag("body") {
+                    +"x"
+                }
+            }
+        }
+    }
+
+    /**
+     * **Place 9** — Inline raw HTML (`<…>` inside a paragraph, dispatched
+     * via `processInlineCharImpl`) must also auto-close void elements so
+     * the inline open stack stays balanced. Without it, every inline `<br>`
+     * leaves an unmatched frame until block close drains it.
+     */
+    @Test
+    fun `inline void element in paragraph auto-closes`() = runTest {
+        // given
+        val src = "foo<br>bar\n"
+
+        // when
+        val parsed = flowOf(src).parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            "p" {
+                +"foo"
+                tag("br") {}
+                +"bar"
+            }
+        }
+    }
+
+    /**
+     * **Place 10** — A close tag whose name doesn't match the top of the
+     * current frame's `openTags` (but does match a deeper open) must
+     * **drain** the intermediate frames LIFO and close the match. Before
+     * the fix, the close fired its `unmark` unconditionally, leaving inner
+     * opens dangling and producing an unbalanced stream.
+     */
+    @Test
+    fun `mismatched close drains inner tags LIFO`() = runTest {
+        // given
+        val src = "<div>\n<span><b>text</span>\n</div>\n"
+
+        // when
+        val parsed = flowOf(src).parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents(tagged = true) {
+            tag("div") {
+                +"\n"
+                tag("span") {
+                    tag("b") {
+                        +"text"
+                    }
+                }
+                +"\n"
+            }
+        }
+    }
+
+    /**
+     * **Place 11** — A close tag with no matching open in the current
+     * frame's `openTags` must be dropped silently (HTML5 parser rule:
+     * "an end tag whose tag name is not in the stack of open elements is
+     * a parse error; ignore the token"). Before the fix, the close fired
+     * an orphan `unmark` event with no matching `mark`, breaking the
+     * downstream stack-based renderer.
+     */
+    @Test
+    fun `orphan close tag with no matching open is dropped`() = runTest {
+        // given
+        val src = "<div>text</span></div>\n"
+
+        // when
+        val parsed = flowOf(src).parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents(tagged = true) {
+            tag("div") {
+                +"text"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Found while running the parser against a BBC News-style HTML document. Each issue has a minimal repro in `HtmlParsingTest.kt` (Places 1–11).

- **Raw-text bodies are now opaque.** Type-1 block bodies (`<script>` / `<style>`) no longer get tokenized — content like `var s = "<div>hi</div>"` stays literal instead of opening nested marks (Places 5, 6).
- **Disallowed tags in HTML 6/7 opener chains are filtered.** `<html><head><title>…` no longer leaks `<title>` through as a tagged mark; single-line bodies of disallowed tags (`<style>…</style>`) are made opaque to subsequent tokenization (Places 2, 3, 4).
- **HTML5 void elements auto-close** (`<meta>`, `<br>`, `<img>`, `<input>`, `<link>`, `<hr>`, …) everywhere they're parsed: HTML 6/7 first line, opener chain, content lines, and inline `<…>` dispatch (Places 7, 8, 9).
- **Mismatched/orphan close tags are handled per HTML5 parser rules.** A close whose name doesn't match the top of `openTags` drains inner opens LIFO and closes the matched ancestor; a close with no matching open at all is dropped silently — keeping the downstream event stream balanced (Places 10, 11).
- **Adjacent type-1 blocks on the same line.** `</script><style>…` now re-runs HTML block detection on the trailing content so the second block opens correctly (Place 1).
- **§6.9 extended autolinks suppressed inside HTML raw-text** via a new `htmlRawTextDepth` counter on `AutolinkCollector` — CSS `url(https://…)` inside a nested `<style>` no longer becomes an `<a>` (Place 2).

## Test plan

- [ ] `./gradlew :markanywhere-parse:jvmTest` passes (including the new `HtmlParsingTest`)
- [ ] Full multiplatform test suite (`./gradlew allTests`) passes
- [ ] Run the parser against a real-world HTML page (e.g. BBC News front page) and confirm no spurious autolinks, no leaked `<title>`/`<style>` marks, and a balanced event stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)