### PR TITLE
Parse DOCTYPE declarations as structural doctype events

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ If you have transformed XML trees with XSLT, the model should feel familiar — 
 | Display math | `$$`…`$$` on own lines | `<math display="block">` |
 | Front matter | `---`/`+++` fence at document start | `<frontmatter format="yaml|toml">` |
 | Namespaced tags | `<ns:tag attr="val">` | `Mark(name="ns:tag", isTagged=true)` |
+| DOCTYPE declaration | `<!DOCTYPE html>` (case-insensitive) | `Mark(name="doctype", isTagged=true)` |
 
 **Namespaced tags** let you embed arbitrary custom markup in a Markdown document. Any `<namespace:tagname …>` / `</namespace:tagname>` pair passes through as `Mark`/`Unmark` events with `isTagged = true` and parsed attributes — your renderer handles them however it wants. This covers use cases like custom card components, alert boxes, or any domain-specific block type without requiring new parser syntax.
 

--- a/markanywhere-parse/README.md
+++ b/markanywhere-parse/README.md
@@ -87,6 +87,18 @@ Normal Markdown content here.
 
 → `Mark("frontmatter", attributes={"format": "yaml"})` + text content + `Unmark("frontmatter")`, followed by the regular document events.
 
+### DOCTYPE declaration (`<!DOCTYPE …>`)
+
+A CommonMark §4.6 type-4 declaration that case-insensitively starts with `<!DOCTYPE` is emitted structurally as a `doctype` mark instead of the GFM raw-HTML pass-through:
+
+```html
+<!DOCTYPE html>
+```
+
+→ `Mark("doctype", isTagged=true)` + `Text("html")` + `Unmark("doctype", isTagged=true)`
+
+The content text is everything between `<!DOCTYPE` and the closing `>`, with the whitespace run immediately after the keyword stripped (so `<!DOCTYPE   html>` and `<!DOCTYPE\thtml>` both yield `"html"`). Multi-line declarations preserve continuation-line whitespace verbatim, joined by `\n`. Generic type-4 declarations that are not DOCTYPE (e.g. `<!ENTITY …>`) still pass through as raw text.
+
 ### Namespaced custom tags (`<ns:tag …>`)
 
 Any `<namespace:tagname attr="value">` / `</namespace:tagname>` pair in the source passes through as `Mark`/`Unmark` events with `isTagged = true` and fully parsed attributes. This lets you embed custom structured markup in a Markdown document without any parser changes — your downstream renderer handles the semantics:

--- a/markanywhere-parse/src/commonMain/kotlin/MarkanywhereParser.kt
+++ b/markanywhere-parse/src/commonMain/kotlin/MarkanywhereParser.kt
@@ -917,10 +917,17 @@ private const val DOCTYPE_PREFIX_LENGTH = "<!DOCTYPE".length
 
 /**
  * True if [line] is the opener of a DOCTYPE declaration (a structurally
- * distinguished subset of HTML block type 4). Allows up to 3 leading spaces,
- * matches `<!DOCTYPE` case-insensitively, and requires the next char (if any)
- * to be a space, tab, or `>`. The caller should have already confirmed the
- * line is type 4 — this is a narrower predicate.
+ * distinguished subset of HTML block type 4). Matches `<!DOCTYPE`
+ * case-insensitively, and requires the next char (if any) to be a space,
+ * tab, or `>`.
+ *
+ * The 3-leading-spaces limit for HTML blocks is enforced by callers — see
+ * [detectHtmlBlockType], which rejects `leadingSpaces > 3` before calling
+ * this predicate with a pre-trimmed line. Inside [detectHtmlBlockType] this
+ * function plays two roles: it acts as the type-4 detector for the
+ * lowercase `<!doctype …>` form (CommonMark restricts type 4 to uppercase),
+ * and it gates the structural DOCTYPE path for the uppercase form already
+ * recognised as type 4.
  */
 private fun isDoctypeLine(line: String): Boolean {
     val trimmed = line.trimStart(' ')
@@ -5074,6 +5081,13 @@ private class ParserState(
      * is seen the block closes (emits `unmark`); any trailing chars after
      * `>` are emitted as a top-level text event with `\n`. Unclosed DOCTYPE
      * at EOF is force-closed by the [finalize] drain.
+     *
+     * DIVERGENCE from GFM type-4: a blank line inside the declaration does
+     * not close the block — it streams as `"\n"` content and the block stays
+     * open until `>` or EOF. Same rationale as the HTML 6/7 blank-line
+     * divergence: append-only emission cannot retract the already-emitted
+     * `mark("doctype")`. Multi-line DOCTYPE with an embedded blank line is
+     * malformed in practice, so the cost is theoretical.
      */
     private suspend fun SemanticEventScope.processDoctypeBlock(char: Char) {
         if (char != '\n') {

--- a/markanywhere-parse/src/commonMain/kotlin/MarkanywhereParser.kt
+++ b/markanywhere-parse/src/commonMain/kotlin/MarkanywhereParser.kt
@@ -232,13 +232,16 @@ private class ListContext(
  * [rootTagName] is the lowercased root tag, [openTags] tracks nested still-open
  * tags (root first), and [firstLineBuffer] holds the opening-tag chars until
  * the first `>` is seen (null once parsed). For type 2-5 [closingSeq] is the
- * sequence that ends the block (`-->`, `?>`, `>`, `]]>`).
+ * sequence that ends the block (`-->`, `?>`, `>`, `]]>`). [isDoctype] flags
+ * the structural DOCTYPE subset of type 4 — those emit `mark("doctype")` +
+ * content + `unmark` rather than raw text.
  */
 private class ListHtmlBlockState(
     val type: Int,
     val rootTagName: String = "",
     val rootIsClosingTag: Boolean = false,
-    val closingSeq: String = ""
+    val closingSeq: String = "",
+    val isDoctype: Boolean = false
 ) {
     val openTags: MutableList<String> = mutableListOf()
     var firstLineBuffer: StringBuilder? = StringBuilder()
@@ -878,6 +881,26 @@ private fun tokenizeHtmlLine(line: String): List<HtmlToken> {
     return tokens
 }
 
+private const val DOCTYPE_PREFIX_LENGTH = "<!DOCTYPE".length
+
+/**
+ * True if [line] is the opener of a DOCTYPE declaration (a structurally
+ * distinguished subset of HTML block type 4). Allows up to 3 leading spaces,
+ * matches `<!DOCTYPE` case-insensitively, and requires the next char (if any)
+ * to be a space, tab, or `>`. The caller should have already confirmed the
+ * line is type 4 — this is a narrower predicate.
+ */
+private fun isDoctypeLine(line: String): Boolean {
+    val trimmed = line.trimStart(' ')
+    if (trimmed.length < DOCTYPE_PREFIX_LENGTH) return false
+    if (!trimmed.regionMatches(0, "<!DOCTYPE", 0, DOCTYPE_PREFIX_LENGTH, ignoreCase = true)) {
+        return false
+    }
+    if (trimmed.length == DOCTYPE_PREFIX_LENGTH) return true
+    val next = trimmed[DOCTYPE_PREFIX_LENGTH]
+    return next == ' ' || next == '\t' || next == '>'
+}
+
 /**
  * Detects which CommonMark HTML block type (1-7) a line starts, or 0 if none.
  * The line should not include the trailing newline.
@@ -909,6 +932,13 @@ private fun detectHtmlBlockType(line: String): Int {
 
     // Type 4: <! followed by uppercase ASCII letter
     if (trimmed.length >= 3 && trimmed[0] == '<' && trimmed[1] == '!' && trimmed[2] in 'A'..'Z') return 4
+
+    // markanywhere extension: lowercase `<!doctype …>` is also recognised as
+    // type 4 so it routes through the DOCTYPE structural path. CommonMark
+    // restricts type 4 to uppercase declarations, but DOCTYPE in HTML5 is
+    // explicitly case-insensitive (HTML Living Standard §13.1.3) and the
+    // semantic value is identical regardless of case.
+    if (isDoctypeLine(trimmed)) return 4
 
     // Type 5: <![CDATA[
     if (trimmed.startsWith("<![CDATA[")) return 5
@@ -1042,6 +1072,18 @@ private class ParserState(
 
         /** Types 2–5 (comment / PI / declaration / CDATA): emit each line as raw text. */
         data class HtmlBlock2to5(val closingSequence: String) : BlockMode
+
+        /**
+         * DOCTYPE declaration (subset of type-4): emitted structurally as
+         * `mark("doctype", isTagged = true)` + content text + `unmark`. The
+         * content is everything between `<!DOCTYPE` (case-insensitive) and the
+         * closing `>`, with the whitespace run immediately after `<!DOCTYPE`
+         * stripped on the opener line; subsequent lines (multi-line DOCTYPE)
+         * preserve their leading whitespace verbatim, joined by `\n`. The
+         * close arrives on the first `>` — anything after `>` on that line
+         * flows as a top-level text event with a trailing `\n`.
+         */
+        data object Doctype : BlockMode
 
         /**
          * Types 6/7 (block-level / type-7 tag). Streamed incrementally — the opening
@@ -1850,6 +1892,7 @@ private class ParserState(
             is CustomMarkup -> processCustomMarkup(char, mode.tagName)
             is HtmlBlock1 -> processHtmlBlock1(char, mode)
             is HtmlBlock2to5 -> processHtmlBlock2to5(char, mode)
+            Doctype -> processDoctypeBlock(char)
             is HtmlBlock6or7 -> processHtmlBlock6or7(char, mode)
         }
 
@@ -2865,6 +2908,10 @@ private class ParserState(
                 }
             }
             2, 3, 4, 5 -> {
+                if (type == 4 && isDoctypeLine(line)) {
+                    enterListDoctypeBlock(ctx, line)
+                    return true
+                }
                 val seq = when (type) {
                     2 -> "-->"
                     3 -> "?>"
@@ -2926,6 +2973,10 @@ private class ParserState(
                 emitListHtmlBlock1ContentLine(ctx, state, line)
             }
             2, 3, 4, 5 -> {
+                if (state.isDoctype) {
+                    streamListDoctypeLine(ctx, line)
+                    return
+                }
                 +"$line\n"
                 if (lineContainsClosingSeq(line, state.closingSeq)) {
                     ctx.htmlBlock = null
@@ -3172,10 +3223,66 @@ private class ParserState(
     ) {
         val top = mode.stack.lastOrNull() ?: return
         val state = top.htmlBlock ?: return
+        if (state.isDoctype) {
+            unmark("doctype", isTagged = true)
+            top.htmlBlock = null
+            return
+        }
         val buf = state.firstLineBuffer
         if (buf != null && buf.isNotEmpty()) +"$buf\n"
         while (state.openTags.isNotEmpty()) unmarkHtml(state.openTags.removeLast())
         top.htmlBlock = null
+    }
+
+    /**
+     * Open a DOCTYPE block inside the active list item. Mirrors the top-level
+     * [enterDoctypeBlock] but stores in-flight state on [ctx.htmlBlock] (as a
+     * [ListHtmlBlockState] with [ListHtmlBlockState.isDoctype] = true) instead
+     * of replacing the block mode.
+     */
+    private suspend fun SemanticEventScope.enterListDoctypeBlock(
+        ctx: ListContext,
+        line: String
+    ) {
+        val trimmed = line.trimStart(' ')
+        val afterPrefix = trimmed.substring(DOCTYPE_PREFIX_LENGTH)
+        mark("doctype", isTagged = true)
+        val gtIndex = afterPrefix.indexOf('>')
+        if (gtIndex >= 0) {
+            val content = afterPrefix.substring(0, gtIndex).trimStart(' ', '\t')
+            if (content.isNotEmpty()) +content
+            unmark("doctype", isTagged = true)
+            val trailing = afterPrefix.substring(gtIndex + 1)
+            if (trailing.isNotEmpty()) +"$trailing\n"
+        } else {
+            val content = afterPrefix.trimStart(' ', '\t')
+            if (content.isNotEmpty()) +content
+            ctx.htmlBlock = ListHtmlBlockState(type = 4, isDoctype = true)
+        }
+    }
+
+    /**
+     * Stream a single content line of an open list-internal DOCTYPE block.
+     * Mirrors [processDoctypeBlock]'s `\n` branch but clears [ctx.htmlBlock]
+     * (rather than replacing the block mode) when the closing `>` arrives.
+     * Continuation lines are prefixed with `\n` so consecutive lines join
+     * verbatim — same rationale as [processDoctypeBlock].
+     */
+    private suspend fun SemanticEventScope.streamListDoctypeLine(
+        ctx: ListContext,
+        line: String
+    ) {
+        val gtIndex = line.indexOf('>')
+        if (gtIndex < 0) {
+            +"\n$line"
+            return
+        }
+        val before = line.substring(0, gtIndex)
+        if (before.isNotEmpty()) +"\n$before"
+        unmark("doctype", isTagged = true)
+        val trailing = line.substring(gtIndex + 1)
+        if (trailing.isNotEmpty()) +"$trailing\n"
+        ctx.htmlBlock = null
     }
 
     /**
@@ -4629,6 +4736,10 @@ private class ParserState(
                 processHtmlBlock1('\n', mode)
             }
             2, 3, 4, 5 -> {
+                if (type == 4 && isDoctypeLine(line)) {
+                    enterDoctypeBlock(line)
+                    return
+                }
                 val closingSeq = when (type) {
                     2 -> "-->"
                     3 -> "?>"
@@ -4818,6 +4929,63 @@ private class ParserState(
         if (lineContainsClosingSeq(line, mode.closingSequence)) {
             replaceMode(BlockMode.Start)
         }
+    }
+
+    /**
+     * Open a DOCTYPE block from its first source [line]. Emits
+     * `mark("doctype", isTagged = true)`, then the content between `<!DOCTYPE`
+     * and `>` (or end-of-line) as text, stripping the whitespace run
+     * immediately after `<!DOCTYPE`. On same-line close, also emits the
+     * matching `unmark` and any trailing text after `>` (with a `\n`).
+     * Otherwise enters [BlockMode.Doctype] so subsequent lines stream as
+     * text content until the closing `>`.
+     */
+    private suspend fun SemanticEventScope.enterDoctypeBlock(line: String) {
+        val trimmed = line.trimStart(' ')
+        val afterPrefix = trimmed.substring(DOCTYPE_PREFIX_LENGTH)
+        mark("doctype", isTagged = true)
+        val gtIndex = afterPrefix.indexOf('>')
+        if (gtIndex >= 0) {
+            val content = afterPrefix.substring(0, gtIndex).trimStart(' ', '\t')
+            if (content.isNotEmpty()) +content
+            unmark("doctype", isTagged = true)
+            val trailing = afterPrefix.substring(gtIndex + 1)
+            if (trailing.isNotEmpty()) +"$trailing\n"
+            replaceMode(BlockMode.Start)
+        } else {
+            val content = afterPrefix.trimStart(' ', '\t')
+            if (content.isNotEmpty()) +content
+            replaceMode(BlockMode.Doctype)
+        }
+    }
+
+    /**
+     * Process a character inside a multi-line DOCTYPE block. Each continuation
+     * line's text is prefixed with `\n` so consecutive content lines are
+     * joined verbatim (the opener line's text has no trailing `\n` to avoid
+     * a spurious newline if the input ends with no further content). When `>`
+     * is seen the block closes (emits `unmark`); any trailing chars after
+     * `>` are emitted as a top-level text event with `\n`. Unclosed DOCTYPE
+     * at EOF is force-closed by the [finalize] drain.
+     */
+    private suspend fun SemanticEventScope.processDoctypeBlock(char: Char) {
+        if (char != '\n') {
+            lineBuffer.append(char)
+            return
+        }
+        val line = lineBuffer.toString()
+        lineBuffer.clear()
+        val gtIndex = line.indexOf('>')
+        if (gtIndex < 0) {
+            +"\n$line"
+            return
+        }
+        val before = line.substring(0, gtIndex)
+        if (before.isNotEmpty()) +"\n$before"
+        unmark("doctype", isTagged = true)
+        val trailing = line.substring(gtIndex + 1)
+        if (trailing.isNotEmpty()) +"$trailing\n"
+        replaceMode(BlockMode.Start)
     }
 
     /**
@@ -6802,6 +6970,14 @@ private class ParserState(
                         +"${lineBuffer.toString()}\n"
                         lineBuffer.clear()
                     }
+                    replaceMode(Start)
+                }
+                Doctype -> {
+                    if (lineBuffer.isNotEmpty()) {
+                        +"\n${lineBuffer.toString()}"
+                        lineBuffer.clear()
+                    }
+                    unmark("doctype", isTagged = true)
                     replaceMode(Start)
                 }
                 is HtmlBlock6or7 -> {

--- a/markanywhere-parse/src/commonTest/kotlin/DoctypeTest.kt
+++ b/markanywhere-parse/src/commonTest/kotlin/DoctypeTest.kt
@@ -386,6 +386,27 @@ class DoctypeTest {
     }
 
     @Test
+    fun `should interrupt paragraph with DOCTYPE`() = runTest {
+        // given: CommonMark HTML block types 1-6 (DOCTYPE is type 4) can
+        // interrupt an open paragraph without a preceding blank line.
+        val textFlow = buildText {
+            +"some text\n"
+            +"<!DOCTYPE html>\n"
+        }.chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            "p" { +"some text" }
+            tag("doctype") {
+                +"html"
+            }
+        }
+    }
+
+    @Test
     fun `should pass DOCTYPE through fenced code block as raw text`() = runTest {
         // given: inside a fenced code block, no constructs are parsed — content
         // streams verbatim. The DOCTYPE recognition is suppressed because the

--- a/markanywhere-parse/src/commonTest/kotlin/DoctypeTest.kt
+++ b/markanywhere-parse/src/commonTest/kotlin/DoctypeTest.kt
@@ -1,0 +1,474 @@
+/*
+ * Copyright 2026 Kazimierz Pogoda / Xemantic
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.xemantic.markanywhere.parse
+
+import com.xemantic.kotlin.core.text.buildText
+import com.xemantic.kotlin.test.text.chunkedRandomly
+import com.xemantic.markanywhere.SemanticEvent
+import com.xemantic.markanywhere.flow.mergeAdjacentText
+import com.xemantic.markanywhere.flow.semanticEvents
+import com.xemantic.markanywhere.test.sameAs
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * DOCTYPE declarations (a structural subset of CommonMark §4.6 type-4 HTML
+ * blocks) are parsed as `mark("doctype", isTagged = true)` + content text +
+ * `unmark`, rather than the GFM raw-HTML pass-through.
+ *
+ * Detection:
+ *  - Up to 3 leading spaces, then `<!DOCTYPE` matched case-insensitively.
+ *  - Next char must be space, tab, `>`, or end-of-line (so `<!DOCTYPER>` is
+ *    a generic type-4 declaration, not a DOCTYPE).
+ *
+ * Content:
+ *  - Everything between `<!DOCTYPE` and the first `>` is the content text.
+ *  - The whitespace run immediately after `<!DOCTYPE` on the opener line is
+ *    stripped (it's the keyword/value separator).
+ *  - Multi-line content preserves leading whitespace on continuation lines
+ *    verbatim, joined by `\n`.
+ *  - Anything after the closing `>` flows as a top-level text event with
+ *    a trailing `\n`.
+ */
+class DoctypeTest {
+
+    @Test
+    fun `should emit mark unmark for HTML5 doctype`() = runTest {
+        // given
+        val textFlow = "<!DOCTYPE html>".chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            tag("doctype") {
+                +"html"
+            }
+        }
+    }
+
+    @Test
+    fun `should match DOCTYPE keyword in title case`() = runTest {
+        // given
+        val textFlow = "<!Doctype html>".chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            tag("doctype") {
+                +"html"
+            }
+        }
+    }
+
+    @Test
+    fun `should match DOCTYPE keyword in all lowercase`() = runTest {
+        // given: HTML5 declares DOCTYPE case-insensitive. CommonMark restricts
+        // type-4 to uppercase declarations; markanywhere extends just this
+        // name so the all-lowercase form routes through the structural path.
+        val textFlow = "<!doctype html>".chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            tag("doctype") {
+                +"html"
+            }
+        }
+    }
+
+    @Test
+    fun `should match DOCTYPE keyword with arbitrary mixed casing`() = runTest {
+        // given
+        val textFlow = "<!dOcTyPe html>".chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            tag("doctype") {
+                +"html"
+            }
+        }
+    }
+
+    @Test
+    fun `should always emit lowercase doctype mark name`() = runTest {
+        // given: regardless of source casing, the mark name is normalised to
+        // `doctype` (lowercase) — downstream renderers/transformers can match
+        // by a single canonical name.
+        val textFlow = "<!DOCTYPE html>".chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then: explicit, no DSL — verify the mark name is exactly "doctype"
+        val events = parsed.mergeAdjacentText().toList()
+        val mark = events.first() as SemanticEvent.Mark
+        assertEquals("doctype", mark.name)
+        assertEquals(true, mark.isTagged)
+        val unmark = events.last() as SemanticEvent.Unmark
+        assertEquals("doctype", unmark.name)
+        assertEquals(true, unmark.isTagged)
+    }
+
+    @Test
+    fun `should preserve content casing`() = runTest {
+        // given
+        val textFlow = "<!DOCTYPE HTML>".chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            tag("doctype") {
+                +"HTML"
+            }
+        }
+    }
+
+    @Test
+    fun `should emit empty content for bare DOCTYPE`() = runTest {
+        // given
+        val textFlow = "<!DOCTYPE>".chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            tag("doctype") {}
+        }
+    }
+
+    @Test
+    fun `should collapse leading whitespace run after keyword`() = runTest {
+        // given: tab + multiple spaces between `<!DOCTYPE` and `html`
+        val textFlow = "<!DOCTYPE\t   html>".chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            tag("doctype") {
+                +"html"
+            }
+        }
+    }
+
+    @Test
+    fun `should preserve HTML 4_01 strict PUBLIC declaration as a single text run`() = runTest {
+        // given: HTML 4.01 strict DOCTYPE with FPI (Formal Public Identifier)
+        // and DTD URL. Internal whitespace, double-quoted strings, and the
+        // `//` slashes inside the FPI are all preserved verbatim — no nested
+        // structure is exposed, the whole declaration body lands as one text
+        // event between `Mark("doctype")` and `Unmark("doctype")`.
+        val source = "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\">"
+        val textFlow = source.chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            tag("doctype") {
+                +"HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\""
+            }
+        }
+    }
+
+    @Test
+    fun `should preserve XHTML 1_0 strict PUBLIC declaration`() = runTest {
+        // given
+        val source = "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">"
+        val textFlow = source.chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            tag("doctype") {
+                +"html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\""
+            }
+        }
+    }
+
+    @Test
+    fun `should preserve SYSTEM identifier`() = runTest {
+        // given: HTML5 about:legacy-compat SYSTEM identifier
+        val source = "<!DOCTYPE html SYSTEM \"about:legacy-compat\">"
+        val textFlow = source.chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            tag("doctype") {
+                +"html SYSTEM \"about:legacy-compat\""
+            }
+        }
+    }
+
+    @Test
+    fun `should preserve internal subset square brackets`() = runTest {
+        // given: an XML-style internal DTD subset. Square brackets, semicolons,
+        // and percent-references are content — the parser emits the whole
+        // declaration body as text without trying to interpret any of it.
+        val source = "<!DOCTYPE root [<!ELEMENT root EMPTY>]>"
+        val textFlow = source.chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then: closing `>` is the FIRST `>` — the inner `<!ELEMENT root EMPTY>`
+        // contains a `>` so the DOCTYPE closes there, and the residue `]>`
+        // emits as a trailing top-level text. This is a known limitation: the
+        // declaration grammar is not parsed, only the outermost `<!DOCTYPE`/`>`
+        // pair is recognised.
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            tag("doctype") {
+                +"root [<!ELEMENT root EMPTY"
+            }
+            +"]>\n"
+        }
+    }
+
+    @Test
+    fun `should stream multi-line DOCTYPE`() = runTest {
+        // given
+        val textFlow = buildText {
+            +"<!DOCTYPE html PUBLIC\n"
+            +"  \"-//W3C//DTD HTML 4.01//EN\"\n"
+            +"  \"http://www.w3.org/TR/html4/strict.dtd\">\n"
+        }.chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            tag("doctype") {
+                +"html PUBLIC\n  \"-//W3C//DTD HTML 4.01//EN\"\n  \"http://www.w3.org/TR/html4/strict.dtd\""
+            }
+        }
+    }
+
+    @Test
+    fun `should allow up to 3 leading spaces`() = runTest {
+        // given
+        val textFlow = "   <!DOCTYPE html>".chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            tag("doctype") {
+                +"html"
+            }
+        }
+    }
+
+    @Test
+    fun `should not parse DOCTYPE with 4 leading spaces as declaration`() = runTest {
+        // given: 4+ leading spaces forces an indented code block
+        val textFlow = "    <!DOCTYPE html>".chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            "pre" {
+                "code" {
+                    +"<!DOCTYPE html>\n"
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should keep generic declaration as raw text`() = runTest {
+        // given: type-4 detection still fires for `<!ENTITY …>` etc., but the
+        // DOCTYPE narrowing rejects it — falls back to the existing raw-text path
+        val textFlow = "<!ENTITY foo>".chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            +"<!ENTITY foo>\n"
+        }
+    }
+
+    @Test
+    fun `should not match DOCTYPER as DOCTYPE`() = runTest {
+        // given: name continues past `DOCTYPE` — falls back to raw text
+        val textFlow = "<!DOCTYPER html>".chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            +"<!DOCTYPER html>\n"
+        }
+    }
+
+    @Test
+    fun `should emit trailing text after closing gt as paragraph`() = runTest {
+        // given: GFM treats this as a single type-4 block — anything after `>`
+        // on the same line is part of the raw-HTML content. We split: DOCTYPE
+        // closes at `>` and the trailing text is emitted as a standalone text
+        // event with `\n` (mirrors the type-1 trailing-after-close behaviour).
+        val textFlow = "<!DOCTYPE html>trailing".chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            tag("doctype") {
+                +"html"
+            }
+            +"trailing\n"
+        }
+    }
+
+    @Test
+    fun `should close DOCTYPE before following paragraph`() = runTest {
+        // given
+        val textFlow = buildText {
+            +"<!DOCTYPE html>\n"
+            +"\n"
+            +"hello\n"
+        }.chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            tag("doctype") {
+                +"html"
+            }
+            "p" { +"hello" }
+        }
+    }
+
+    @Test
+    fun `should pass DOCTYPE through fenced code block as raw text`() = runTest {
+        // given: inside a fenced code block, no constructs are parsed — content
+        // streams verbatim. The DOCTYPE recognition is suppressed because the
+        // dispatcher is in CodeBlock mode, not Start mode, when the line arrives.
+        val textFlow = buildText {
+            +"```html\n"
+            +"<!DOCTYPE html>\n"
+            +"```\n"
+        }.chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            "pre" {
+                "code"("class" to "language-html") {
+                    +"<!DOCTYPE html>\n"
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should pass DOCTYPE through indented code block as raw text`() = runTest {
+        // given: a 4-space-indented line is an indented code block — the line's
+        // 4 leading spaces never reach the HTML-block dispatcher, so the DOCTYPE
+        // detector is never asked about this line.
+        val textFlow = buildText {
+            +"some paragraph\n"
+            +"\n"
+            +"    <!DOCTYPE html>\n"
+        }.chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            "p" { +"some paragraph" }
+            "pre" {
+                "code" {
+                    +"<!DOCTYPE html>\n"
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should pass DOCTYPE through inline code span as literal`() = runTest {
+        // given: between backticks the DOCTYPE characters are inline code
+        // content — no block-level dispatch can fire mid-paragraph.
+        val textFlow = "Use `<!DOCTYPE html>` to opt into HTML5.".chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            "p" {
+                +"Use "
+                "code" {
+                    +"<!DOCTYPE html>"
+                }
+                +" to opt into HTML5."
+            }
+        }
+    }
+
+    @Test
+    fun `should force-close unterminated DOCTYPE at EOF`() = runTest {
+        // given: no closing `>` ever arrives — finalize() must still emit
+        // unmark to keep the event stream balanced
+        val textFlow = flowOf("<!DOCTYPE html PUBLIC")
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            tag("doctype") {
+                +"html PUBLIC"
+            }
+        }
+    }
+}

--- a/markanywhere-parse/src/commonTest/kotlin/HtmlBlockInListItemTest.kt
+++ b/markanywhere-parse/src/commonTest/kotlin/HtmlBlockInListItemTest.kt
@@ -434,7 +434,9 @@ class HtmlBlockInListItemTest {
             "ul" {
                 "li" {
                     "p" { +"intro" }
-                    +"<!DOCTYPE html>\n"
+                    tag("doctype") {
+                        +"html"
+                    }
                     "p" { +"after" }
                 }
             }

--- a/markanywhere-parse/src/commonTest/kotlin/gfm/Gfm_04_06_Test.kt
+++ b/markanywhere-parse/src/commonTest/kotlin/gfm/Gfm_04_06_Test.kt
@@ -1117,7 +1117,12 @@ class Gfm_04_06_Test {
          */
     }
 
-    // DIVERGENCE: type-4 (declaration like `<!DOCTYPE>`) emits as raw text.
+    // DIVERGENCE: type-4 (declaration like `<!DOCTYPE>`) is parsed as a
+    // structural `mark("doctype")` + content text + `unmark`, rather than the
+    // GFM raw-HTML pass-through. This is a markanywhere extension — the
+    // declaration-name keyword is well-defined enough to expose semantically,
+    // and downstream consumers (renderers, HTML-aware transformers) often
+    // need to recognise it explicitly.
     @Test
     fun `example 150 - DIVERGENCE - doctype`() = runTest {
         // given
@@ -1128,7 +1133,9 @@ class Gfm_04_06_Test {
 
         // then
         parsed.mergeAdjacentText() sameAs semanticEvents {
-            +"<!DOCTYPE html>\n"
+            tag("doctype") {
+                +"html"
+            }
         }
         // GFM expected:
         /*


### PR DESCRIPTION
## Summary
- Recognise `<!DOCTYPE …>` (case-insensitive, including all-lowercase per HTML5) as a structural subset of CommonMark §4.6 type-4 HTML blocks and emit it as `mark("doctype", isTagged = true)` + content text + `unmark` instead of the GFM raw-HTML pass-through.
- Handle same-line, multi-line, bare (`<!DOCTYPE>`), trailing-text-after-`>`, and unterminated-at-EOF shapes; trailing whitespace run after the `<!DOCTYPE` keyword is stripped on the opener line, continuation-line whitespace is preserved verbatim.
- Wire the same structural path through list items via `ListContext.htmlBlock` (mirrors the existing tables/HTML-blocks-in-list-items pattern — avoids pushing a block-mode frame that would knock `ListBlock` off the dispatcher's top-of-stack slot).
- Generic non-DOCTYPE type-4 declarations (`<!ENTITY …>`, etc.) still flow as raw text; `<!DOCTYPER>` and other non-keyword extensions are rejected and fall back to raw text.

## Test plan
- [x] `DoctypeTest` — 21 new cases covering casing variants, PUBLIC/SYSTEM identifiers, multi-line, leading-space limits, fenced/indented/inline-code suppression, trailing text, and EOF force-close.
- [x] `Gfm_04_06_Test` example 150 updated to reflect the structural event flow (still marked `DIVERGENCE` since GFM passes the line through as raw text).
- [x] `HtmlBlockInListItemTest` DOCTYPE-inside-list case updated to the new event shape.