### PR TITLE
Render SVG and MathML in their DOM namespaces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,6 +218,7 @@ lookahead), it's likely worth doing.
 - For semantic event flow testing, use the overloaded `sameAs` infix on `Flow<SemanticEvent>` (defined in `markanywhere-test`) against a `semanticEvents { ... }` builder — this is event-stream comparison, unrelated to HTML.
 - For asserting rendered HTML output (e.g. in `markanywhere-render` tests), use `sameAsHtml` (not the generic string `sameAs`) — provides syntax highlighting in the IDE.
 - GFM example test naming convention: `example N - <description>` for spec-conformant tests, `example N - DIVERGENCE - <description>` when the parser intentionally diverges from GFM. Keep `DIVERGENCE` in the name even when updating expectations to match the divergent behavior.
+- When asserting on a boolean expression (counts, equality between two nullables, `contains`, etc.), use `assert(expr)` from `com.xemantic.kotlin.test.assert` — it is power-assert-instrumented in the convention plugin, so a failure prints the full expression with subvalues. Do NOT fall back to `kotlin.test.assertEquals` / `assertTrue` / `assertNotNull` — they discard that information. Reserve the `sameAs` family for `String?` receivers (rendered HTML, attribute values, namespace URIs) and `Flow<SemanticEvent>` event-stream comparison; everything else goes through `assert(...)`.
 
 ## Anti-patterns to avoid
 

--- a/markanywhere-js/build.gradle.kts
+++ b/markanywhere-js/build.gradle.kts
@@ -37,6 +37,7 @@ kotlin {
             jsTest {
                 dependencies {
                     implementation(project(":markanywhere-test"))
+                    implementation(project(":markanywhere-parse"))
                     implementation(libs.kotlinx.coroutines.test)
                     implementation(libs.kotlin.test)
                     implementation(libs.xemantic.kotlin.test)

--- a/markanywhere-js/src/jsMain/kotlin/AppendSemanticEvents.kt
+++ b/markanywhere-js/src/jsMain/kotlin/AppendSemanticEvents.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Kazimierz Pogoda / Xemantic
+ * Copyright 2025-2026 Kazimierz Pogoda / Xemantic
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,19 +21,32 @@ import kotlinx.browser.document
 import kotlinx.coroutines.flow.Flow
 import org.w3c.dom.Element
 
+private const val HTML_NS = "http://www.w3.org/1999/xhtml"
+private const val SVG_NS = "http://www.w3.org/2000/svg"
+private const val MATHML_NS = "http://www.w3.org/1998/Math/MathML"
+private const val XLINK_NS = "http://www.w3.org/1999/xlink"
+private const val XML_NS = "http://www.w3.org/XML/1998/namespace"
+private const val XMLNS_NS = "http://www.w3.org/2000/xmlns/"
+
+private val HTML_ENCODINGS = setOf("text/html", "application/xhtml+xml")
+
 public suspend fun Element.appendSemanticEvents(
     events: Flow<SemanticEvent>
 ) {
 
     val path = mutableListOf(this)
+    val childNamespaceStack = mutableListOf(namespaceURI ?: HTML_NS)
 
     events.collect { event ->
         when (event) {
 
             is SemanticEvent.Mark -> {
-                val element = event.toElement()
+                val parentChildNs = childNamespaceStack.last()
+                val elementNs = resolveElementNamespace(event.name, parentChildNs)
+                val element = event.toElement(elementNs)
                 path.last().appendChild(element)
                 path += element
+                childNamespaceStack += resolveChildrenNamespace(event, elementNs)
             }
 
             is SemanticEvent.Text -> {
@@ -45,16 +58,50 @@ public suspend fun Element.appendSemanticEvents(
             is SemanticEvent.Unmark -> {
                 path.last().normalize()
                 path.removeLast()
+                childNamespaceStack.removeLast()
             }
 
         }
     }
 }
 
-private fun SemanticEvent.Mark.toElement(): Element {
-    val element = document.createElement(name)
+private fun resolveElementNamespace(
+    name: String,
+    parentChildNs: String
+): String = when (name) {
+    "svg" -> SVG_NS
+    "math" -> MATHML_NS
+    else -> parentChildNs
+}
+
+private fun resolveChildrenNamespace(
+    mark: SemanticEvent.Mark,
+    elementNs: String
+): String = when {
+    elementNs == SVG_NS && mark.name == "foreignObject" -> HTML_NS
+    elementNs == MATHML_NS
+        && mark.name == "annotation-xml"
+        && mark.attributes?.get("encoding") in HTML_ENCODINGS -> HTML_NS
+    else -> elementNs
+}
+
+private fun SemanticEvent.Mark.toElement(
+    elementNs: String
+): Element {
+    val element = document.createElementNS(elementNs, name)
     attributes?.forEach { (key, value) ->
-        element.setAttribute(key, value)
+        val attrNs = attributeNamespace(key)
+        if (attrNs == null) element.setAttribute(key, value)
+        else element.setAttributeNS(attrNs, key, value)
     }
     return element
+}
+
+private fun attributeNamespace(
+    name: String
+): String? = when {
+    name == "xmlns" || name.startsWith("xmlns:") -> XMLNS_NS
+    name.startsWith("xlink:") -> XLINK_NS
+    name.startsWith("xml:") -> XML_NS
+    else -> null
 }

--- a/markanywhere-js/src/jsTest/kotlin/AppendSemanticEventsNamespaceTest.kt
+++ b/markanywhere-js/src/jsTest/kotlin/AppendSemanticEventsNamespaceTest.kt
@@ -1,0 +1,615 @@
+/*
+ * Copyright 2026 Kazimierz Pogoda / Xemantic
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.xemantic.markanywhere.js
+
+import com.xemantic.kotlin.test.assert
+import com.xemantic.kotlin.test.coroutines.should
+import com.xemantic.kotlin.test.have
+import com.xemantic.markanywhere.parse.parse
+import kotlinx.browser.document
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.w3c.dom.Element
+import kotlin.test.Test
+
+class AppendSemanticEventsNamespaceTest {
+
+    @Test
+    fun `should create non-xmlns svg root element in SVG namespace`() = runTest {
+        // given
+        val div = document.createElement("div")
+        val events = flowOf("""
+            <svg/>
+        """.trimIndent()).parse()
+
+        // when
+        div.appendSemanticEvents(events)
+
+        // then
+        div.child("svg") should {
+            have(namespaceURI == SVG_NS)
+        }
+    }
+
+    @Test
+    fun `should create svg descendants in SVG namespace when root has no xmlns`() = runTest {
+        // given
+        val div = document.createElement("div")
+        val events = flowOf("""
+            <svg viewBox="0 0 100 100">
+            <g>
+            <rect x="10" y="10" width="80" height="80"/>
+            <circle cx="50" cy="50" r="20"/>
+            </g>
+            </svg>
+        """.trimIndent()).parse()
+
+        // when
+        div.appendSemanticEvents(events)
+
+        // then
+        div.child("svg") should {
+            have(namespaceURI == SVG_NS)
+            child("g") should {
+                have(namespaceURI == SVG_NS)
+                child("rect") should {
+                    have(namespaceURI == SVG_NS)
+                }
+                child("circle") should {
+                    have(namespaceURI == SVG_NS)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should create svg root element in SVG namespace`() = runTest {
+        // given
+        val div = document.createElement("div")
+        val events = flowOf("""
+            <svg xmlns="$SVG_NS"/>
+        """.trimIndent()).parse()
+
+        // when
+        div.appendSemanticEvents(events)
+
+        // then
+        div.child("svg") should {
+            have(namespaceURI == SVG_NS)
+        }
+    }
+
+    @Test
+    fun `should create svg descendants in SVG namespace`() = runTest {
+        // given
+        val div = document.createElement("div")
+        val events = flowOf("""
+            <svg xmlns="$SVG_NS" viewBox="0 0 100 100">
+            <g>
+            <rect x="10" y="10" width="80" height="80"/>
+            <circle cx="50" cy="50" r="20"/>
+            </g>
+            </svg>
+        """.trimIndent()).parse()
+
+        // when
+        div.appendSemanticEvents(events)
+
+        // then
+        div.child("svg") should {
+            have(namespaceURI == SVG_NS)
+            child("g") should {
+                have(namespaceURI == SVG_NS)
+                child("rect") should {
+                    have(namespaceURI == SVG_NS)
+                }
+                child("circle") should {
+                    have(namespaceURI == SVG_NS)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should preserve SVG namespace for deeply nested camelCase elements`() = runTest {
+        // given
+        val div = document.createElement("div")
+        val events = flowOf("""
+            <svg xmlns="$SVG_NS">
+            <defs>
+            <linearGradient id="g1">
+            <stop offset="0%" stop-color="red"/>
+            </linearGradient>
+            <clipPath id="c1">
+            <rect width="10" height="10"/>
+            </clipPath>
+            </defs>
+            </svg>
+        """.trimIndent()).parse()
+
+        // when
+        div.appendSemanticEvents(events)
+
+        // then
+        div.child("svg") should {
+            child("defs") should {
+                have(namespaceURI == SVG_NS)
+                child("linearGradient") should {
+                    have(namespaceURI == SVG_NS)
+                    have(localName == "linearGradient")
+                    child("stop") should {
+                        have(namespaceURI == SVG_NS)
+                    }
+                }
+                child("clipPath") should {
+                    have(namespaceURI == SVG_NS)
+                    have(localName == "clipPath")
+                    child("rect") should {
+                        have(namespaceURI == SVG_NS)
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should create non-xmlns math root element in MathML namespace`() = runTest {
+        // given
+        val div = document.createElement("div")
+        val events = flowOf("""
+            <math/>
+        """.trimIndent()).parse()
+
+        // when
+        div.appendSemanticEvents(events)
+
+        // then
+        div.child("math") should {
+            have(namespaceURI == MATHML_NS)
+        }
+    }
+
+    @Test
+    fun `should create MathML descendants in MathML namespace when root has no xmlns`() = runTest {
+        // given
+        val div = document.createElement("div")
+        val events = flowOf("""
+            <math>
+            <mrow>
+            <mi>x</mi>
+            </mrow>
+            </math>
+        """.trimIndent()).parse()
+
+        // when
+        div.appendSemanticEvents(events)
+
+        // then
+        div.child("math") should {
+            have(namespaceURI == MATHML_NS)
+            child("mrow") should {
+                have(namespaceURI == MATHML_NS)
+                child("mi") should {
+                    have(namespaceURI == MATHML_NS)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should create math root element in MathML namespace`() = runTest {
+        // given
+        val div = document.createElement("div")
+        val events = flowOf("""
+            <math xmlns="$MATHML_NS"/>
+        """.trimIndent()).parse()
+
+        // when
+        div.appendSemanticEvents(events)
+
+        // then
+        div.child("math") should {
+            have(namespaceURI == MATHML_NS)
+        }
+    }
+
+    @Test
+    fun `should create MathML descendants in MathML namespace`() = runTest {
+        // given
+        val div = document.createElement("div")
+        val events = flowOf("""
+            <math xmlns="$MATHML_NS">
+            <mrow>
+            <mi>x</mi>
+            <mo>=</mo>
+            <mfrac>
+            <mn>1</mn>
+            <mn>2</mn>
+            </mfrac>
+            </mrow>
+            </math>
+        """.trimIndent()).parse()
+
+        // when
+        div.appendSemanticEvents(events)
+
+        // then
+        div.child("math") should {
+            have(namespaceURI == MATHML_NS)
+            child("mrow") should {
+                have(namespaceURI == MATHML_NS)
+                child("mi") should {
+                    have(namespaceURI == MATHML_NS)
+                }
+                child("mo") should {
+                    have(namespaceURI == MATHML_NS)
+                }
+                child("mfrac") should {
+                    have(namespaceURI == MATHML_NS)
+                    for (i in 0 until children.length) {
+                        children.item(i)!! should {
+                            have(namespaceURI == MATHML_NS)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should keep foreignObject in SVG namespace but switch children back to HTML`() = runTest {
+        // given
+        val div = document.createElement("div")
+        val events = flowOf("""
+            <svg xmlns="$SVG_NS">
+            <foreignObject x="0" y="0" width="100" height="100">
+            <p>HTML inside SVG<strong>!</strong></p>
+            </foreignObject>
+            </svg>
+        """.trimIndent()).parse()
+
+        // when
+        div.appendSemanticEvents(events)
+
+        // then
+        div.child("svg") should {
+            have(namespaceURI == SVG_NS)
+            child("foreignObject") should {
+                have(namespaceURI == SVG_NS)
+                have(localName == "foreignObject")
+                child("p") should {
+                    have(namespaceURI == HTML_NS)
+                    child("strong") should {
+                        have(namespaceURI == HTML_NS)
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should restore SVG namespace after foreignObject closes`() = runTest {
+        // given
+        val div = document.createElement("div")
+        val events = flowOf("""
+            <svg xmlns="$SVG_NS">
+            <foreignObject width="100" height="100">
+            <p>HTML island</p>
+            </foreignObject>
+            <rect width="50" height="50"/>
+            </svg>
+        """.trimIndent()).parse()
+
+        // when
+        div.appendSemanticEvents(events)
+
+        // then
+        div.child("svg") should {
+            child("rect") should {
+                have(namespaceURI == SVG_NS)
+            }
+        }
+    }
+
+    @Test
+    fun `should switch annotation-xml children to HTML when encoding is text-html`() = runTest {
+        // given
+        val div = document.createElement("div")
+        val events = flowOf("""
+            <math xmlns="$MATHML_NS">
+            <semantics>
+            <mrow><mi>x</mi></mrow>
+            <annotation-xml encoding="text/html">
+            <p>fallback HTML</p>
+            </annotation-xml>
+            </semantics>
+            </math>
+        """.trimIndent()).parse()
+
+        // when
+        div.appendSemanticEvents(events)
+
+        // then
+        div.child("math") should {
+            child("semantics") should {
+                have(namespaceURI == MATHML_NS)
+                child("mrow") should {
+                    have(namespaceURI == MATHML_NS)
+                }
+                child("annotation-xml") should {
+                    have(namespaceURI == MATHML_NS)
+                    child("p") should {
+                        have(namespaceURI == HTML_NS)
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should keep annotation-xml children in MathML when encoding is missing`() = runTest {
+        // given
+        val div = document.createElement("div")
+        val events = flowOf("""
+            <math xmlns="$MATHML_NS">
+            <semantics>
+            <annotation-xml>
+            <ci>x</ci>
+            </annotation-xml>
+            </semantics>
+            </math>
+        """.trimIndent()).parse()
+
+        // when
+        div.appendSemanticEvents(events)
+
+        // then
+        div.child("math") should {
+            child("semantics") should {
+                child("annotation-xml") should {
+                    have(namespaceURI == MATHML_NS)
+                    child("ci") should {
+                        have(namespaceURI == MATHML_NS)
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should keep annotation-xml children in MathML when encoding is not HTML`() = runTest {
+        // given
+        val div = document.createElement("div")
+        val events = flowOf("""
+            <math xmlns="$MATHML_NS">
+            <semantics>
+            <annotation-xml encoding="MathML-Content">
+            <ci>x</ci>
+            </annotation-xml>
+            </semantics>
+            </math>
+        """.trimIndent()).parse()
+
+        // when
+        div.appendSemanticEvents(events)
+
+        // then
+        div.child("math") should {
+            child("semantics") should {
+                child("annotation-xml") should {
+                    have(namespaceURI == MATHML_NS)
+                    child("ci") should {
+                        have(namespaceURI == MATHML_NS)
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should keep HTML siblings in HTML namespace next to an SVG block`() = runTest {
+        // given
+        val div = document.createElement("div")
+        val events = flowOf("""
+            <p>before</p>
+
+            <svg xmlns="$SVG_NS">
+            <rect width="10" height="10"/>
+            </svg>
+
+            <p>after</p>
+        """.trimIndent()).parse()
+
+        // when
+        div.appendSemanticEvents(events)
+
+        // then
+        div.child("p") should {
+            have(namespaceURI == HTML_NS)
+        }
+        div.child("svg") should {
+            have(namespaceURI == SVG_NS)
+            child("rect") should {
+                have(namespaceURI == SVG_NS)
+            }
+        }
+        val ps = (0 until div.children.length)
+            .mapNotNull { div.children.item(it) }
+            .filter { it.localName == "p" }
+        assert(ps.size == 2)
+        for (p in ps) {
+            p should {
+                have(namespaceURI == HTML_NS)
+            }
+        }
+    }
+
+    @Test
+    fun `should handle SVG nested inside HTML inside foreignObject inside SVG`() = runTest {
+        // given
+        val div = document.createElement("div")
+        val events = flowOf("""
+            <svg xmlns="$SVG_NS">
+            <foreignObject width="100" height="100">
+            <div>
+            <svg xmlns="$SVG_NS">
+            <circle r="5"/>
+            </svg>
+            </div>
+            </foreignObject>
+            </svg>
+        """.trimIndent()).parse()
+
+        // when
+        div.appendSemanticEvents(events)
+
+        // then
+        div.child("svg") should {
+            have(namespaceURI == SVG_NS)
+            child("foreignObject") should {
+                have(namespaceURI == SVG_NS)
+                child("div") should {
+                    have(namespaceURI == HTML_NS)
+                    child("svg") should {
+                        have(namespaceURI == SVG_NS)
+                        child("circle") should {
+                            have(namespaceURI == SVG_NS)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should set xlink href attribute in XLink namespace`() = runTest {
+        // given
+        val div = document.createElement("div")
+        val events = flowOf("""
+            <svg xmlns="$SVG_NS" xmlns:xlink="$XLINK_NS">
+            <use xlink:href="#icon"/>
+            </svg>
+        """.trimIndent()).parse()
+
+        // when
+        div.appendSemanticEvents(events)
+
+        // then
+        div.child("svg") should {
+            have(getAttributeNS(XMLNS_NS, "xlink") == XLINK_NS)
+            child("use") should {
+                have(getAttributeNS(XLINK_NS, "href") == "#icon")
+            }
+        }
+    }
+
+    @Test
+    fun `should set xml lang attribute in XML namespace`() = runTest {
+        // given
+        val div = document.createElement("div")
+        val events = flowOf("""
+            <svg xmlns="$SVG_NS">
+            <text xml:lang="en" xml:space="preserve">Hello</text>
+            </svg>
+        """.trimIndent()).parse()
+
+        // when
+        div.appendSemanticEvents(events)
+
+        // then
+        div.child("svg") should {
+            child("text") should {
+                have(getAttributeNS(XML_NS, "lang") == "en")
+                have(getAttributeNS(XML_NS, "space") == "preserve")
+            }
+        }
+    }
+
+    @Test
+    fun `should set plain attributes without namespace on SVG element`() = runTest {
+        // given
+        val div = document.createElement("div")
+        val events = flowOf("""
+            <svg xmlns="$SVG_NS" viewBox="0 0 100 100">
+            <rect width="10" height="10" fill="red"/>
+            </svg>
+        """.trimIndent()).parse()
+
+        // when
+        div.appendSemanticEvents(events)
+
+        // then
+        div.child("svg") should {
+            child("rect") should {
+                have(getAttribute("width") == "10")
+                have(getAttribute("height") == "10")
+                have(getAttribute("fill") == "red")
+                have(getAttributeNS(null, "width") == "10")
+            }
+        }
+    }
+
+    @Test
+    fun `should round-trip svg through toSemanticEvents and appendSemanticEvents preserving namespaces`() = runTest {
+        // given
+        val source = document.createElement("div")
+        source.innerHTML = """<svg xmlns="http://www.w3.org/2000/svg"><g><rect width="10" height="10"></rect></g></svg>"""
+        val sourceSvg = source.child("svg")
+        sourceSvg should {
+            have(namespaceURI == SVG_NS)
+        }
+
+        val target = document.createElement("div")
+        val events = flowOf("""
+            <svg xmlns="$SVG_NS">
+            <g>
+            <rect width="10" height="10"/>
+            </g>
+            </svg>
+        """.trimIndent()).parse()
+
+        // when
+        target.appendSemanticEvents(events)
+
+        // then
+        target.child("svg") should {
+            have(namespaceURI == sourceSvg.namespaceURI)
+            child("g") should {
+                have(namespaceURI == SVG_NS)
+                child("rect") should {
+                    have(namespaceURI == SVG_NS)
+                }
+            }
+        }
+    }
+
+}
+
+private const val HTML_NS = "http://www.w3.org/1999/xhtml"
+private const val SVG_NS = "http://www.w3.org/2000/svg"
+private const val MATHML_NS = "http://www.w3.org/1998/Math/MathML"
+private const val XLINK_NS = "http://www.w3.org/1999/xlink"
+private const val XML_NS = "http://www.w3.org/XML/1998/namespace"
+private const val XMLNS_NS = "http://www.w3.org/2000/xmlns/"
+
+private fun Element.child(
+    name: String
+): Element = requireNotNull(
+    (0 until children.length).asSequence()
+        .mapNotNull { children.item(it) }
+        .firstOrNull { it.localName == name }
+) { "no child element with localName='$name'" }

--- a/markanywhere-js/src/jsTest/kotlin/AppendSemanticEventsTest.kt
+++ b/markanywhere-js/src/jsTest/kotlin/AppendSemanticEventsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Kazimierz Pogoda / Xemantic
+ * Copyright 2025-2026 Kazimierz Pogoda / Xemantic
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
+package com.xemantic.markanywhere.js
+
 import com.xemantic.kotlin.test.sameAs
 import com.xemantic.markanywhere.flow.semanticEvents
-import com.xemantic.markanywhere.js.appendSemanticEvents
 import kotlinx.browser.document
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test

--- a/markanywhere-js/src/jsTest/kotlin/ElementToSemanticEventsTest.kt
+++ b/markanywhere-js/src/jsTest/kotlin/ElementToSemanticEventsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Kazimierz Pogoda / Xemantic
+ * Copyright 2025-2026 Kazimierz Pogoda / Xemantic
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
+package com.xemantic.markanywhere.js
+
 import com.xemantic.markanywhere.flow.semanticEvents
-import com.xemantic.markanywhere.js.toSemanticEvents
 import com.xemantic.markanywhere.test.sameAs
 import kotlinx.browser.document
 import kotlinx.coroutines.test.runTest

--- a/markanywhere-js/src/jsTest/kotlin/SvgElementToSemanticEventsTest.kt
+++ b/markanywhere-js/src/jsTest/kotlin/SvgElementToSemanticEventsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Kazimierz Pogoda / Xemantic
+ * Copyright 2025-2026 Kazimierz Pogoda / Xemantic
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
+package com.xemantic.markanywhere.js
+
 import com.xemantic.markanywhere.flow.semanticEvents
-import com.xemantic.markanywhere.js.toSemanticEvents
 import com.xemantic.markanywhere.test.sameAs
 import kotlinx.browser.document
 import kotlinx.coroutines.test.runTest


### PR DESCRIPTION
## Summary

- `Element.appendSemanticEvents` now tracks a per-child namespace stack so `<svg>` / `<math>` and their descendants are created via `createElementNS`, regardless of whether the source carries an `xmlns` attribute. Previously every element was created in the parent's namespace, so SVG and MathML rendered as unstyled HTML.
- HTML5 foreign-content re-entry handled: `<foreignObject>` switches children back to HTML; `<annotation-xml encoding="text/html">` switches children to HTML while non-HTML encodings stay in MathML.
- Attribute namespacing: `xmlns` / `xmlns:*` → xmlns NS, `xlink:*` → XLink, `xml:*` → XML; everything else stays unnamespaced via `setAttribute`.

## Test plan

- [ ] `./gradlew :markanywhere-js:jsTest` passes — new `AppendSemanticEventsNamespaceTest` covers SVG / MathML roots with and without `xmlns`, deep camelCase descendants (`linearGradient`, `clipPath`), `foreignObject` re-entry, `annotation-xml` encoding variants, HTML siblings around foreign-content blocks, and namespaced attributes (`xlink:href`, `xml:lang`).
- [ ] Existing `AppendSemanticEventsTest` / `ElementToSemanticEventsTest` / `SvgElementToSemanticEventsTest` still pass after the package move into `com.xemantic.markanywhere.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)