### PR TITLE
Recognise inline math opener when followed by a backslash

### DIFF
--- a/markanywhere-parse/src/commonMain/kotlin/MarkanywhereParser.kt
+++ b/markanywhere-parse/src/commonMain/kotlin/MarkanywhereParser.kt
@@ -5551,6 +5551,17 @@ private class ParserState(
                 inlineBuffer.append('\\')
                 return
             }
+            // A pending `$` opener whose next char is `\` is a math opener
+            // (LaTeX command, e.g. `$\int x$`). `isMathOpenChar('\\')` is true,
+            // so defer to the math-open path rather than flushing `$` as literal
+            // and consuming `\` as a backslash escape.
+            if (inlineBuffer.toString() == "$") {
+                inlineBuffer.clear()
+                mark("math")
+                math = true
+                pendingDeferredChar = char
+                return
+            }
             if (inlineBuffer.isNotEmpty()) {
                 +inlineBuffer.toString()
                 inlineBuffer.clear()

--- a/markanywhere-parse/src/commonTest/kotlin/MarkanywhereParserTest.kt
+++ b/markanywhere-parse/src/commonTest/kotlin/MarkanywhereParserTest.kt
@@ -647,7 +647,7 @@ class MarkanywhereParserTest {
     @Test
     fun `should parse inline math`() = runTest {
         // given
-        
+
         val textFlow = $$"""
             The equation $E = mc^2$ is famous.
         """.trimIndent().chunkedRandomly().asFlow()
@@ -661,6 +661,108 @@ class MarkanywhereParserTest {
                 +"The equation "
                 "math" { +"E = mc^2" }
                 +" is famous."
+            }
+        }
+    }
+
+    @Test
+    fun `should parse two inline math expressions in same paragraph`() = runTest {
+        // given
+        val textFlow = $$"""
+            Inline: $E = mc^2$ and $\int_0^\infty e^{-x^2}\,dx = \tfrac{\sqrt{\pi}}{2}$
+        """.trimIndent().chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            "p" {
+                +"Inline: "
+                "math" { +"E = mc^2" }
+                +" and "
+                "math" { +"""\int_0^\infty e^{-x^2}\,dx = \tfrac{\sqrt{\pi}}{2}""" }
+            }
+        }
+    }
+
+    @Test
+    fun `should open inline math when content starts with a LaTeX command`() = runTest {
+        // given
+        val textFlow = $$"""
+            See $\int x\,dx$ here.
+        """.trimIndent().chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            "p" {
+                +"See "
+                "math" { +"""\int x\,dx""" }
+                +" here."
+            }
+        }
+    }
+
+    @Test
+    fun `should not confuse caret-runs inside inline math with sup`() = runTest {
+        // given
+        val textFlow = $$"""
+            **Third item** — with math: $\sum_{i=1}^{n} i = \frac{n(n+1)}{2}$
+        """.trimIndent().chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            "p" {
+                "strong" { +"Third item" }
+                +" — with math: "
+                "math" { +"""\sum_{i=1}^{n} i = \frac{n(n+1)}{2}""" }
+            }
+        }
+    }
+
+    @Test
+    fun `should close inline math before trailing sentence punctuation`() = runTest {
+        // given
+        val textFlow = $$"""
+            **Third item** — with math: $\sum_{i=1}^{n} i = \frac{n(n+1)}{2}$.
+        """.trimIndent().chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            "p" {
+                "strong" { +"Third item" }
+                +" — with math: "
+                "math" { +"""\sum_{i=1}^{n} i = \frac{n(n+1)}{2}""" }
+                +"."
+            }
+        }
+    }
+
+    @Test
+    fun `should parse two inline math expressions both starting with LaTeX commands`() = runTest {
+        // given
+        val textFlow = $$"""
+            $\frac{a}{b}$ and $\sqrt{c}$
+        """.trimIndent().chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            "p" {
+                "math" { +"""\frac{a}{b}""" }
+                +" and "
+                "math" { +"""\sqrt{c}""" }
             }
         }
     }


### PR DESCRIPTION
## Summary
- A pending `$` opener whose next char is `\` is now treated as a LaTeX-command math opener (e.g. `$\int x$`, `$\frac{a}{b}$`). Previously the backslash branch flushed `$` as literal text and consumed the `\` as a backslash escape, dropping the math span entirely.
- The fix is one branch in `processInlineCharImpl`'s `\` handler: when `inlineBuffer` holds exactly `"$"`, clear it, emit `mark("math")`, set `math = true`, and defer the `\` via `pendingDeferredChar` so `isMathOpenChar('\\')` drives the math content path.
- Adds five tests: two-math-spans-per-paragraph, LaTeX-command opener, caret-runs-inside-math (vs. `sup` confusion), math closing before trailing punctuation, and back-to-back LaTeX-command spans.

## Test plan
- [ ] `./gradlew :markanywhere-parse:jvmTest` passes (new tests + existing inline math test).
- [ ] No regression in `Gfm_06_14_Test` (math extension) or other inline-related suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)