### PR TITLE
Add wrapInSections: group heading-delimited siblings into id-carrying sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ See [markanywhere-parse/README.md](markanywhere-parse/README.md) for a full list
 | `markanywhere-js`        | Kotlin/JS DOM renderer                                              |
 | `markanywhere-dump`      | Injectable browser bundle exposing `window.markanywhere.dump()` — captures a live page's DOM as `SemanticEventDump` JSON |
 | `markanywhere-browse`    | Drives real Chrome over CDP (via `kdriver`) to capture a live page as a `SemanticEventDump` and act on it by element reference |
-| `markanywhere-html`      | HTML→Markdown pipeline `transformHtmlToMarkdown` (`resolveIcons`, `simplifyHtml`, `dropBlankInlineFormatting`, whitespace normalization, `encodeActionableRefs`), plus `applyAccessibility` and `wrapInHtmlDocument` |
+| `markanywhere-html`      | HTML→Markdown pipeline `transformHtmlToMarkdown` (`resolveIcons`, `simplifyHtml`, `dropBlankInlineFormatting`, whitespace normalization, `encodeActionableRefs`), plus `applyAccessibility`, `wrapInHtmlDocument`, and `wrapInSections` |
 | `markanywhere-test`      | Test helpers: `sameAs` for asserting `Flow<SemanticEvent>` equality |
 
 You can depend only on `markanywhere-parse` and consume the `Flow<SemanticEvent>` with your own renderer — the API surface is a single three-variant sealed class. The `markanywhere-transform` module additionally lets you intercept and rewrite events before they reach any renderer.

--- a/markanywhere-html/src/commonMain/kotlin/WrapInSections.kt
+++ b/markanywhere-html/src/commonMain/kotlin/WrapInSections.kt
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2026 Kazimierz Pogoda / Xemantic
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.xemantic.markanywhere.html
+
+import com.xemantic.markanywhere.SemanticEvent
+import com.xemantic.markanywhere.flow.semanticEvents
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Groups every mark named [tagName] and its following siblings into a
+ * synthetic `section` mark carrying an `id` derived from the heading text.
+ *
+ * `wrapInSections("h2")` turns a flat heading-delimited stream into an
+ * explicitly sectioned one: `<h2>A</h2><p>a</p><h2>B</h2><p>b</p>` becomes
+ * `<section id="a"><h2>A</h2><p>a</p></section><section id="b"><h2>B</h2><p>b</p></section>`.
+ * See the matcher overload for the full semantics.
+ */
+public fun Flow<SemanticEvent>.wrapInSections(
+    tagName: String
+): Flow<SemanticEvent> = wrapInSections { mark -> mark.name == tagName }
+
+/**
+ * Groups every mark matched by [sectionStart] and its following siblings into
+ * a synthetic `section` mark carrying an `id` derived from the heading text.
+ *
+ * When a matching [Mark][SemanticEvent.Mark] arrives, a `section` opens right
+ * before it and stays open across the matched mark and all of its following
+ * siblings. The section closes at whichever comes first:
+ *
+ * - the next matching sibling mark — which immediately opens the next section,
+ * - the closing unmark of the enclosing container,
+ * - the end of the stream.
+ *
+ * The section's `id` is the anchor form of the matched subtree's flattened
+ * text (nested marks stripped away): trimmed, lowercased, letters/digits/`-`/`_`
+ * kept, whitespace replaced with `-`, everything else dropped — the GitHub
+ * heading-anchor convention. A repeated id gains a `-1`/`-2`/… suffix so ids
+ * stay unique within the stream; a heading yielding no anchor characters
+ * produces a section without an `id`.
+ *
+ * Content preceding the first match flows through untouched. Sectioning is
+ * per-sibling-level: a match nested deeper inside an open section starts its
+ * own nested `section` there, closed by the same rules. The synthetic mark
+ * mirrors the matched mark's [isTagged][SemanticEvent.Mark.isTagged], and
+ * every `section` mark is guaranteed a matching unmark, so a balanced input
+ * stays balanced.
+ *
+ * Buffering is bounded to the matched mark's own subtree — its events are held
+ * between the mark and its balanced unmark so the `id` can be derived before
+ * the `section` opens, then replayed verbatim. Everything else is forwarded as
+ * it arrives.
+ *
+ * @param sectionStart decides, from an opening mark, whether it starts a section.
+ */
+public fun Flow<SemanticEvent>.wrapInSections(
+    sectionStart: (SemanticEvent.Mark) -> Boolean
+): Flow<SemanticEvent> = semanticEvents {
+
+    // count of currently open source marks; a section opened by a match at
+    // depth d wraps siblings living exactly at depth d
+    var depth = 0
+    // open synthetic sections, innermost last
+    val openSections = ArrayDeque<OpenSection>()
+    val usedIds = mutableSetOf<String>()
+
+    // the matched mark's subtree, buffered between its mark and balanced
+    // unmark so the section id can be derived from the flattened text
+    var headingEvents: MutableList<SemanticEvent>? = null
+    var headingDepth = 0
+    var headingIsTagged = false
+    val headingText = StringBuilder()
+
+    suspend fun closeSection() {
+        val section = openSections.removeLast()
+        unmark("section", isTagged = section.isTagged)
+    }
+
+    suspend fun openSectionFromHeading() {
+        val events = headingEvents!!
+        headingEvents = null
+        val id = anchorId(headingText.toString(), usedIds)
+        headingText.clear()
+        mark(
+            "section",
+            isTagged = headingIsTagged,
+            attributes = id?.let { mapOf("id" to it) } ?: emptyMap()
+        )
+        openSections += OpenSection(depth, headingIsTagged)
+        emit(events)
+    }
+
+    collect { event ->
+        val heading = headingEvents
+        if (heading != null) {
+            heading += event
+            when (event) {
+                is Mark -> headingDepth++
+                is Text -> headingText.append(event.text)
+                is Unmark -> if (--headingDepth == 0) {
+                    openSectionFromHeading()
+                }
+            }
+        } else when (event) {
+            is Mark -> if (sectionStart(event)) {
+                if (openSections.lastOrNull()?.depth == depth) {
+                    closeSection()
+                }
+                headingEvents = mutableListOf(event)
+                headingDepth = 1
+                headingIsTagged = event.isTagged
+            } else {
+                depth++
+                emit(event)
+            }
+            is Text -> emit(event)
+            is Unmark -> {
+                // an unmark arriving at the section's own sibling level closes
+                // the enclosing container, so the section must close first
+                while (openSections.lastOrNull()?.let { it.depth >= depth } == true) {
+                    closeSection()
+                }
+                depth--
+                emit(event)
+            }
+        }
+    }
+
+    // an unclosed matched mark (broken upstream contract) still opens its
+    // section so no buffered events are lost
+    if (headingEvents != null) {
+        openSectionFromHeading()
+    }
+    while (openSections.isNotEmpty()) {
+        closeSection()
+    }
+}
+
+private class OpenSection(
+    val depth: Int,
+    val isTagged: Boolean
+)
+
+// The GitHub heading-anchor convention: trim, lowercase, keep letters,
+// digits, `-`, `_`; whitespace becomes `-`; everything else is dropped.
+// Duplicates gain a `-1`/`-2`/… suffix; an all-dropped title yields null.
+private fun anchorId(
+    title: String,
+    usedIds: MutableSet<String>
+): String? {
+    val slug = buildString {
+        for (c in title.trim().lowercase()) {
+            when {
+                c.isLetterOrDigit() || c == '-' || c == '_' -> append(c)
+                c.isWhitespace() -> append('-')
+            }
+        }
+    }
+    if (slug.isEmpty()) return null
+    if (usedIds.add(slug)) return slug
+    var counter = 1
+    while (true) {
+        val candidate = "$slug-$counter"
+        if (usedIds.add(candidate)) return candidate
+        counter++
+    }
+}

--- a/markanywhere-html/src/commonTest/kotlin/WrapInSectionsTest.kt
+++ b/markanywhere-html/src/commonTest/kotlin/WrapInSectionsTest.kt
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2026 Kazimierz Pogoda / Xemantic
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.xemantic.markanywhere.html
+
+import com.xemantic.markanywhere.flow.semanticEvents
+import com.xemantic.markanywhere.test.sameAs
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+/**
+ * [wrapInSections] groups a section-starting mark (e.g. `h2`) and all of its
+ * following siblings into a synthetic `section` mark, closing the section at
+ * the next section-starting sibling, at the close of the enclosing container,
+ * or at the end of the stream.
+ */
+class WrapInSectionsTest {
+
+    @Test
+    fun `should wrap heading and following siblings in a section until the next heading`() = runTest {
+        // given
+        val input = semanticEvents {
+            "h1" { +"Title" }
+            "p" { +"Intro." }
+            "h2" { +"First" }
+            "p" { +"First body." }
+            "h2" { +"Second" }
+            "p" { +"Second body." }
+        }
+
+        // when
+        val output = input.wrapInSections("h2")
+
+        // then
+        output sameAs semanticEvents {
+            "h1" { +"Title" }
+            "p" { +"Intro." }
+            "section"("id" to "first") {
+                "h2" { +"First" }
+                "p" { +"First body." }
+            }
+            "section"("id" to "second") {
+                "h2" { +"Second" }
+                "p" { +"Second body." }
+            }
+        }
+    }
+
+    @Test
+    fun `should close an open section before the enclosing container closes`() = runTest {
+        // given
+        val input = semanticEvents {
+            "body" {
+                "h2" { +"Heading" }
+                "p" { +"Body." }
+            }
+            "footer" { +"Footer." }
+        }
+
+        // when
+        val output = input.wrapInSections("h2")
+
+        // then
+        output sameAs semanticEvents {
+            "body" {
+                "section"("id" to "heading") {
+                    "h2" { +"Heading" }
+                    "p" { +"Body." }
+                }
+            }
+            "footer" { +"Footer." }
+        }
+    }
+
+    @Test
+    fun `should keep nested containers inside the section`() = runTest {
+        // given
+        val input = semanticEvents {
+            "h2" { +"Heading" }
+            "div" {
+                "p" { +"Nested." }
+            }
+            "p" { +"Sibling." }
+        }
+
+        // when
+        val output = input.wrapInSections("h2")
+
+        // then
+        output sameAs semanticEvents {
+            "section"("id" to "heading") {
+                "h2" { +"Heading" }
+                "div" {
+                    "p" { +"Nested." }
+                }
+                "p" { +"Sibling." }
+            }
+        }
+    }
+
+    @Test
+    fun `should start a nested section for a matching mark at a deeper level`() = runTest {
+        // given
+        val input = semanticEvents {
+            "h2" { +"Outer" }
+            "div" {
+                "h2" { +"Inner" }
+                "p" { +"Inner body." }
+            }
+            "p" { +"Outer body." }
+        }
+
+        // when
+        val output = input.wrapInSections("h2")
+
+        // then
+        output sameAs semanticEvents {
+            "section"("id" to "outer") {
+                "h2" { +"Outer" }
+                "div" {
+                    "section"("id" to "inner") {
+                        "h2" { +"Inner" }
+                        "p" { +"Inner body." }
+                    }
+                }
+                "p" { +"Outer body." }
+            }
+        }
+    }
+
+    @Test
+    fun `should forward a stream without matching marks verbatim`() = runTest {
+        // given
+        val input = semanticEvents {
+            "h1" { +"Title" }
+            "p" { +"Body." }
+        }
+
+        // when
+        val output = input.wrapInSections("h2")
+
+        // then
+        output sameAs semanticEvents {
+            "h1" { +"Title" }
+            "p" { +"Body." }
+        }
+    }
+
+    @Test
+    fun `should match section starts with a custom mark matcher`() = runTest {
+        // given
+        val input = semanticEvents {
+            "h2"("class" to "chapter") { +"One" }
+            "p" { +"One body." }
+            "h2" { +"Plain heading" }
+            "h2"("class" to "chapter") { +"Two" }
+            "p" { +"Two body." }
+        }
+
+        // when
+        val output = input.wrapInSections { mark ->
+            mark.name == "h2" && mark["class"] == "chapter"
+        }
+
+        // then
+        output sameAs semanticEvents {
+            "section"("id" to "one") {
+                "h2"("class" to "chapter") { +"One" }
+                "p" { +"One body." }
+                "h2" { +"Plain heading" }
+            }
+            "section"("id" to "two") {
+                "h2"("class" to "chapter") { +"Two" }
+                "p" { +"Two body." }
+            }
+        }
+    }
+
+    @Test
+    fun `should strip tags and non-anchor characters when deriving the section id`() = runTest {
+        // given
+        val input = semanticEvents {
+            "h2" {
+                "em" { +"Fancy" }
+                +" Title 2.0!"
+            }
+            "p" { +"Body." }
+        }
+
+        // when
+        val output = input.wrapInSections("h2")
+
+        // then
+        output sameAs semanticEvents {
+            "section"("id" to "fancy-title-20") {
+                "h2" {
+                    "em" { +"Fancy" }
+                    +" Title 2.0!"
+                }
+                "p" { +"Body." }
+            }
+        }
+    }
+
+    @Test
+    fun `should deduplicate repeated section ids`() = runTest {
+        // given
+        val input = semanticEvents {
+            "h2" { +"Same" }
+            "p" { +"One." }
+            "h2" { +"Same" }
+            "p" { +"Two." }
+            "h2" { +"Same" }
+            "p" { +"Three." }
+        }
+
+        // when
+        val output = input.wrapInSections("h2")
+
+        // then
+        output sameAs semanticEvents {
+            "section"("id" to "same") {
+                "h2" { +"Same" }
+                "p" { +"One." }
+            }
+            "section"("id" to "same-1") {
+                "h2" { +"Same" }
+                "p" { +"Two." }
+            }
+            "section"("id" to "same-2") {
+                "h2" { +"Same" }
+                "p" { +"Three." }
+            }
+        }
+    }
+
+    @Test
+    fun `should omit the id when the heading yields no anchor characters`() = runTest {
+        // given
+        val input = semanticEvents {
+            "h2" { +"!!!" }
+            "p" { +"Body." }
+        }
+
+        // when
+        val output = input.wrapInSections("h2")
+
+        // then
+        output sameAs semanticEvents {
+            "section" {
+                "h2" { +"!!!" }
+                "p" { +"Body." }
+            }
+        }
+    }
+
+    @Test
+    fun `should mirror the tagged flag of the matched mark on the section`() = runTest {
+        // given
+        val input = semanticEvents(tagged = true) {
+            "h2" { +"Heading" }
+            "p" { +"Body." }
+        }
+
+        // when
+        val output = input.wrapInSections("h2")
+
+        // then
+        output sameAs semanticEvents(tagged = true) {
+            "section"("id" to "heading") {
+                "h2" { +"Heading" }
+                "p" { +"Body." }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary

New `markanywhere-html` operator `Flow<SemanticEvent>.wrapInSections` with two overloads:

- `wrapInSections(tagName: String)` — e.g. `wrapInSections("h2")`
- `wrapInSections(sectionStart: (SemanticEvent.Mark) -> Boolean)` — full mark matcher (name, attributes, `isTagged`)

When a matching mark arrives, a synthetic `<section>` opens before it and wraps the mark plus all of its following siblings, closing at the next matching sibling (which opens the next section), at the enclosing container's unmark, or at end of stream.

The section carries an `id` derived from the matched subtree's flattened text (nested marks stripped), following the GitHub heading-anchor convention: trimmed, lowercased, letters/digits/`-`/`_` kept, whitespace → `-`, everything else dropped. Repeated ids gain `-1`/`-2`/… suffixes; a heading with no anchor characters yields a section without an `id`.

## Design notes

- Buffering is bounded to the matched mark's own subtree (held between its mark and balanced unmark so the `id` is known before the `section` opens); everything else streams through as it arrives.
- The synthetic mark mirrors the matched mark's `isTagged`; every emitted `section` mark is guaranteed a matching unmark, so a balanced input stays balanced. An unclosed matched mark at end of stream still flushes its buffer, losing no events.
- Sectioning is per-sibling-level: a match nested deeper inside an open section starts its own nested section there.

## Testing

TDD red→green: `WrapInSectionsTest` (10 tests) covers sibling grouping, container-close and end-of-stream section closing, nested containers, nested matches, custom matcher, tagged mirroring, id derivation/dedup/omission. Full `:markanywhere-html:jvmTest` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)