### PR TITLE
Resolve entity references inside ATX headings

### DIFF
--- a/markanywhere-parse/src/commonMain/kotlin/MarkanywhereParser.kt
+++ b/markanywhere-parse/src/commonMain/kotlin/MarkanywhereParser.kt
@@ -1860,7 +1860,7 @@ private class ParserState(
             val heading = blockMode
             if (heading is BlockMode.Heading &&
                 inlineBuffer.isEmpty() && !escaped && !code && !math &&
-                !inLink && !inImage && inlineRawSkipTag == null
+                !inLink && !inImage && !inEntityRef && inlineRawSkipTag == null
             ) {
                 if (!heading.contentStarted && heading.pendingSpaces.isEmpty()) {
                     var skip = index
@@ -2358,15 +2358,17 @@ private class ParserState(
             ' ', '\t' -> when {
                 // Leading whitespace before any content or closing-# candidate.
                 !mode.contentStarted && mode.pendingSpaces.isEmpty() -> {}
-                // Pending delimiter or escape needs this char now to resolve
-                // flanking. Route directly — pendingSpaces is reserved for
+                // Pending delimiter, escape, or entity ref needs this char now
+                // to resolve. Route directly — pendingSpaces is reserved for
                 // trailing-or-closing material observed with a clean inline
                 // state.
-                inlineBuffer.isNotEmpty() || escaped -> processInlineChar(char)
+                inlineBuffer.isNotEmpty() || escaped || inEntityRef ->
+                    processInlineChar(char)
                 else -> mode.pendingSpaces.append(char)
             }
             '#' -> when {
-                inlineBuffer.isNotEmpty() || escaped -> processInlineChar(char)
+                inlineBuffer.isNotEmpty() || escaped || inEntityRef ->
+                    processInlineChar(char)
                 // Potential closing-#: a `#` that follows the opening's
                 // whitespace (no content yet) or that follows already-buffered
                 // trailing material. Defer; flushed as content if non-trailing

--- a/markanywhere-parse/src/commonTest/kotlin/MarkanywhereParserTest.kt
+++ b/markanywhere-parse/src/commonTest/kotlin/MarkanywhereParserTest.kt
@@ -418,6 +418,38 @@ class MarkanywhereParserTest {
     }
 
     @Test
+    fun `should keep a literal ampersand in place inside a heading`() = runTest {
+        // given
+        val textFlow = """
+            ### Agentic AI & Creative Coding
+        """.trimIndent().chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            "h3" { +"Agentic AI & Creative Coding" }
+        }
+    }
+
+    @Test
+    fun `should decode an entity reference inside a heading`() = runTest {
+        // given
+        val textFlow = """
+            # Fish &amp; Chips
+        """.trimIndent().chunkedRandomly().asFlow()
+
+        // when
+        val parsed = textFlow.parse()
+
+        // then
+        parsed.mergeAdjacentText() sameAs semanticEvents {
+            "h1" { +"Fish & Chips" }
+        }
+    }
+
+    @Test
     fun `should escape HTML in code blocks`() = runTest {
         // given
         


### PR DESCRIPTION
## Summary

Entity-reference state (`inEntityRef`) was not consulted in two heading paths, so a `&` inside an ATX heading could be mishandled:

- the heading fast-path in `processChunk` now stays off while an entity reference is in flight, so no substring emit bypasses the entity state machine;
- the heading `' '`/`'#'` deferral (`pendingSpaces` / closing-`#` candidates) now routes the char through `processInlineChar` when `inEntityRef` is set — an in-flight `&copy<space>`-style body needs that char to resolve (commit or abort), mirroring the existing `inlineBuffer`/`escaped` exceptions.

Result: `### Agentic AI & Creative Coding` keeps its literal ampersand in place, and `# Fish &amp; Chips` decodes to `Fish & Chips`.

## Testing

Two new regression tests in `MarkanywhereParserTest` (`should keep a literal ampersand in place inside a heading`, `should decode an entity reference inside a heading`); full `:markanywhere-parse:jvmTest` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)