### PR TITLE
Rework the README transformer example into a single streaming pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,24 +176,25 @@ Note: Typically `markdownFlow: Flow<String>` represents a Markdown text stream, 
 Each reusable rule set is an extension on `TransformerBuilder` — think of one as an XSLT stylesheet you can compose with others:
 
 ```kotlin
-fun TransformerBuilder.demoteHeadings() {
-    match("h1") { "h2" { children() } } // re-emit <h1> as <h2>, keeping its content
-}
+flowOf(markdown).parse().transform {
 
-fun TransformerBuilder.emphasizeToStrong() {
-    match("em") { "strong" { children() } } // re-emit <em> as <strong>
-}
+    // re-emit <h1> as <h2>, keeping its content
+    match("h1") {
+        "h2" { children() }
+    }
 
-println(
-    flowOf(markdown)
-        .parse()
-        .transform {
-            demoteHeadings()
-            emphasizeToStrong()
-            passthrough() // copy every other mark and its text verbatim
-        }
-        .render()
-)
+    // re-emit <em> as <strong>
+    match("em") {
+        "strong" { children() }
+    }
+
+    // copy every other mark and its text verbatim
+    passthrough()
+
+}.asHtml().collect {
+    // incremental output
+    println(it)
+}
 ```
 
 Will print:


### PR DESCRIPTION
## Summary

Replaces the "Transforming the event stream" README example — previously two named `TransformerBuilder` extensions composed via `transform { … }` and printed with `render()` — with a single inline `parse().transform { … }.asHtml().collect { … }` pipeline, showing the incremental streaming consumption path directly.

Documentation-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)