### PR TITLE
Observe document, not documentElement, in waitForDomIdle

### DIFF
--- a/markanywhere-browse/src/commonMain/kotlin/WaitUntilLoaded.kt
+++ b/markanywhere-browse/src/commonMain/kotlin/WaitUntilLoaded.kt
@@ -138,6 +138,14 @@ public suspend fun Tab.waitForNetworkIdle(
  * (resolving `true`) or the [timeout] cap is hit (resolving `false`). Running
  * the debounce inside the page avoids round-tripping every mutation over CDP.
  *
+ * The observed target is `document`, not `document.documentElement`: right
+ * after a navigation commits there is a window in which the new document has
+ * no document element yet, and `observe(null)` throws `TypeError: parameter 1
+ * is not of type 'Node'` — which, called on the heels of a click that
+ * navigates, fails the whole wait. A `Document` is always a `Node`, and
+ * `subtree: true` from it covers everything `documentElement` would have,
+ * including a document element that appears (or is replaced) later.
+ *
  * @return `true` if the DOM went quiet, `false` if [timeout] elapsed first.
  */
 public suspend fun Tab.waitForDomIdle(
@@ -163,7 +171,7 @@ public suspend fun Tab.waitForDomIdle(
                 timer = setTimeout(() => finish(true), quiet);
               };
               const observer = new MutationObserver(bump);
-              observer.observe(document.documentElement, {
+              observer.observe(document, {
                 subtree: true, childList: true, attributes: true, characterData: true
               });
               bump();

--- a/markanywhere-browse/src/commonTest/kotlin/WaitUntilLoadedTest.kt
+++ b/markanywhere-browse/src/commonTest/kotlin/WaitUntilLoadedTest.kt
@@ -67,6 +67,24 @@ class WaitUntilLoadedTest {
     }
 
     @Test
+    fun `waitForDomIdle should report idle on a document with no document element`() = runTest {
+        val idle = runInBrowser { browser ->
+            // given — a document whose documentElement is gone, standing in for the
+            // window right after a navigation commits, before the new document has
+            // one; observing it directly would throw "parameter 1 is not of type
+            // 'Node'" and fail every click that navigates
+            val tab = browser.get(testPageUrl("simple.html"))
+            tab.rawEvaluate("document.removeChild(document.documentElement)")
+
+            // when
+            tab.waitForDomIdle(quietTime = 300.milliseconds, timeout = 10.seconds)
+        }
+
+        // then — the wait completes normally, and the empty document is quiet
+        assert(idle)
+    }
+
+    @Test
     fun `waitForNetworkIdle should report idle on a page issuing no requests`() = runTest {
         val idle = runInBrowser { browser ->
             // given — a fully static page whose load requests have settled


### PR DESCRIPTION
## The bug

`waitForDomIdle` installs its `MutationObserver` on `document.documentElement`. Right after a navigation commits there is a window in which the new document does not have a document element yet, so that argument is `null` and the page throws:

```
TypeError: Failed to execute 'observe' on 'MutationObserver': parameter 1 is not of type 'Node'
```

Because `waitForDomIdle` is one leg of `waitUntilLoaded`, this surfaces on the path where it hurts most — a click that navigates. Found in [Umwelt](https://github.com/xemantic/umwelt), submitting a Google search form: the click went through and the browser landed on the results page, but the caller got an exception instead of a `Navigation`, and its recorded location stayed on the page the tab had already left.

## The fix

Observe `document` instead. A `Document` is always a `Node`, and `subtree: true` from it covers everything `documentElement` would have, including a document element that appears — or is replaced — later. Strictly wider coverage, no null to guard.

## Test

`waitForDomIdle should report idle on a document with no document element` removes the document element outright, standing in for that post-commit window (the real timing is a race and would make a flaky test; the precondition it produces is identical).

Verified it is a real regression test — with the old line restored it fails with the exact production error:

```
<test-failure test="...WaitUntilLoadedTest.waitForDomIdle should report idle on a document with no document element()" platform="jvm">
Error evaluating expression: ... TypeError: Failed to execute 'observe' on 'MutationObserver': parameter 1 is not of type 'Node'.
</test-failure>
```

Full `WaitUntilLoadedTest` suite green on `jvmTest` with the fix in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)